### PR TITLE
IOS-8649: Fixed Navbar issue

### DIFF
--- a/Sources/Views/TogglesView.swift
+++ b/Sources/Views/TogglesView.swift
@@ -57,34 +57,32 @@ public struct TogglesView: View {
     }
 
     public var body: some View {
-        NavigationView {
-            List {
-                ForEach(searchResults) { group in
-                    Section(header: Text(group.title)) {
-                        ForEach(group.toggles) { toggle in
-                            navigationLink(toggle: toggle)
-                        }
+        List {
+            ForEach(searchResults) { group in
+                Section(header: Text(group.title)) {
+                    ForEach(group.toggles) { toggle in
+                        navigationLink(toggle: toggle)
                     }
-                    .accessibilityLabel(group.accessibilityLabel)
                 }
+                .accessibilityLabel(group.accessibilityLabel)
             }
+        }
 #if os(iOS)
-            .listStyle(.insetGrouped)
+        .listStyle(.insetGrouped)
 #endif
-            .accessibilityLabel("Toggles list")
-            .navigationTitle("Toggles")
-            .toolbar {
-                if manager.hasOverrides {
-                    toolbarView
-                }
+        .accessibilityLabel("Toggles list")
+        .navigationTitle("Toggles")
+        .toolbar {
+            if manager.hasOverrides {
+                toolbarView
             }
-            .searchable(text: $searchText, prompt: "Filter toggles")
-            .alert("Cleared overrides", isPresented: $presentDeleteAlert) {
-                Button("OK!", role: .cancel) {}
-            } message: {
-                let variables = overriddenVariables.joined(separator: "\n")
-                Text("The overrides for the following variables have been deleted:\n\n\(variables)")
-            }
+        }
+        .searchable(text: $searchText, prompt: "Filter toggles")
+        .alert("Cleared overrides", isPresented: $presentDeleteAlert) {
+            Button("OK!", role: .cancel) {}
+        } message: {
+            let variables = overriddenVariables.joined(separator: "\n")
+            Text("The overrides for the following variables have been deleted:\n\n\(variables)")
         }
     }
     

--- a/TogglesDemo/TogglesDemo/Sources/DemoView.swift
+++ b/TogglesDemo/TogglesDemo/Sources/DemoView.swift
@@ -9,10 +9,12 @@ struct DemoView: View {
     
     var body: some View {
         TabView {
-            TogglesView(manager: viewModel.manager, datasourceUrl: viewModel.datasourceUrl)
-                .tabItem {
-                    Label("Toggles", systemImage: "switch.2")
-                }
+            NavigationView {
+                TogglesView(manager: viewModel.manager, datasourceUrl: viewModel.datasourceUrl)
+                    .tabItem {
+                        Label("Toggles", systemImage: "switch.2")
+                    }
+            }
             RemoteValueProviderView(provider: viewModel.remoteValueProvider, manager: viewModel.manager)
                 .tabItem {
                     Label("Config update", systemImage: "icloud.and.arrow.down")


### PR DESCRIPTION
Fixed navbar issue when calling TogglesView from inside a UIKit NavigationController (via UIHostingController) which leads to a bug where there is two navigation bars)

Removed NavigationView from TogglesView, and placed it inside the Toggles Demo App so when TogglesView is called outside of the demo app, the navbars are not duplicated if one already exists.