### PR TITLE
IOS-8858: Fix Toggles UI 'Clear Overrides bug'

### DIFF
--- a/Sources/Views/TogglesView.swift
+++ b/Sources/Views/TogglesView.swift
@@ -103,10 +103,12 @@ public struct TogglesView: View {
         }
         .confirmationDialog("Select an action", isPresented: $showingOptions) {
             Button("Clear overrides") {
-                DispatchQueue.main.async {
-                    overriddenVariables = manager.removeOverrides()
+                Task {
+                    await MainActor.run {
+                        overriddenVariables = manager.removeOverrides()
+                        presentDeleteAlert = true
+                    }
                 }
-                presentDeleteAlert = true
             }
         }
     }

--- a/Sources/Views/TogglesView.swift
+++ b/Sources/Views/TogglesView.swift
@@ -103,7 +103,9 @@ public struct TogglesView: View {
         }
         .confirmationDialog("Select an action", isPresented: $showingOptions) {
             Button("Clear overrides") {
-                overriddenVariables = manager.removeOverrides()
+                DispatchQueue.main.async {
+                    overriddenVariables = manager.removeOverrides()
+                }
                 presentDeleteAlert = true
             }
         }

--- a/TogglesDemo/TogglesDemo.xcodeproj/project.pbxproj
+++ b/TogglesDemo/TogglesDemo.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				"OTHER_SWIFT_FLAGS[arch=*]" = "-Xfrontend -enable-actor-data-race-checks";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";


### PR DESCRIPTION
There was a bug spotted by @albertodebortoli where the 'Clear Overrides' dialog is shown twice (shown again after selecting 'Clear Overrides').

After some investigation this is because the `List` `View` is re-drawn whilst the `removeOverrides()` function is called, but before it has finished. Once it has finished `hasOverrides` is set to `false` which prevents the dialog from being displayed again.

I have placed the call to this function inside a closure for it to be called on the main thread so it is completed before the `List` `View` is redrawn.

This also allows the correct view to be displayed after Clear Overrides is tapped, as shown below.

Before (bug)
https://github.com/TogglesPlatform/Toggles/assets/24379144/801d864d-0488-480f-9243-6782fb72a9d1

After (fix)
https://github.com/TogglesPlatform/Toggles/assets/24379144/c3711014-3c71-42f9-8d0c-cdc40fd901b0

After 2.0 (updated fix)
https://github.com/TogglesPlatform/Toggles/assets/24379144/95f09cea-d324-46d9-9761-2cc0427ce720



