### PR TITLE
Update Toggles to not throw incorrectParameterSize error when decrypting empty strings

### DIFF
--- a/Sources/ToggleManager/ToggleManager+Ciphering.swift
+++ b/Sources/ToggleManager/ToggleManager+Ciphering.swift
@@ -45,7 +45,7 @@ extension ToggleManager {
             throw FetchError.missingCipherConfiguration
         }
         
-        if value == "" && cipherConfiguration.ignoreEmptyStrings {
+        if value.isEmpty && cipherConfiguration.ignoreEmptyStrings {
             return ""
         }
         

--- a/Sources/ToggleManager/ToggleManager+Ciphering.swift
+++ b/Sources/ToggleManager/ToggleManager+Ciphering.swift
@@ -1,5 +1,7 @@
 //  ToggleManager+Ciphering.swift
 
+import CryptoKit
+
 extension ToggleManager {
     
     enum FetchError: Error {
@@ -42,6 +44,11 @@ extension ToggleManager {
         guard let cipherConfiguration = cipherConfiguration else {
             throw FetchError.missingCipherConfiguration
         }
+        
+        if value == "" && cipherConfiguration.ignoreEmptyStrings {
+            return ""
+        }
+        
         let cipher: Ciphering
         switch cipherConfiguration.algorithm {
         case Algorithm.chaCha20Poly1305:

--- a/Sources/Utilities/CipherConfiguration.swift
+++ b/Sources/Utilities/CipherConfiguration.swift
@@ -16,9 +16,11 @@ public typealias CipherKey = String
 public struct CipherConfiguration {
     let algorithm: Algorithm
     let key: CipherKey
+    let ignoreEmptyStrings: Bool
     
-    public init(algorithm: Algorithm, key: CipherKey) {
+    public init(algorithm: Algorithm, key: CipherKey, ignoreEmptyStrings: Bool = false) {
         self.algorithm = algorithm
         self.key = key
+        self.ignoreEmptyStrings = ignoreEmptyStrings
     }
 }

--- a/Tests/Utilities/CipherConfiguration+Defaults.swift
+++ b/Tests/Utilities/CipherConfiguration+Defaults.swift
@@ -8,4 +8,8 @@ extension CipherConfiguration {
     static let chaChaPoly: CipherConfiguration = {
         CipherConfiguration(algorithm: .chaCha20Poly1305, key: "AyUcYw-qWebYF-z0nWZ4")
     }()
+    
+    static let chaChaPolyWithIgnoreEmptyStrings: CipherConfiguration = {
+        CipherConfiguration(algorithm: .chaCha20Poly1305, key: "AyUcYw-qWebYF-z0nWZ4", ignoreEmptyStrings: true)
+    }()
 }


### PR DESCRIPTION
Update Toggles to not throw incorrectParameterSize error when decrypting empty strings

I have gone with a statement to check for an empty string rather than catch the incorrectParameterSize error.

This is so only the case where "" is passed in will be ignored (if the option is selected in the CipherConfiguration)

If the incorrectParameterSize error is thrown for any other reason it will still be raised.