### PR TITLE
Add Toggles functionality to verify values

### DIFF
--- a/Sources/Extensions/Value+Semi-Equatable.swift
+++ b/Sources/Extensions/Value+Semi-Equatable.swift
@@ -1,0 +1,22 @@
+//  Value+Semi-Equatable.swift
+
+import Foundation
+
+extension Value {
+    static func ~=(lhs: Value, rhs: Value) -> Bool {
+        switch lhs {
+        case .bool:
+            if case .bool = rhs { return true }
+        case .int:
+            if case .int = rhs { return true }
+        case .number:
+            if case .number = rhs { return true }
+        case .string:
+            if case .string = rhs { return true }
+        case .secure:
+            if case .secure = rhs { return true }
+        }
+        return false
+    }
+}
+

--- a/Sources/Extensions/Value+Utilities.swift
+++ b/Sources/Extensions/Value+Utilities.swift
@@ -36,6 +36,21 @@ extension Value {
         }
     }
     
+    var toggleTypeDescription: String {
+        switch self {
+        case .bool:
+            return "Bool"
+        case .int:
+            return "Int"
+        case .number:
+            return "Double"
+        case .string:
+            return "String"
+        case .secure:
+            return "Secure"
+        }
+    }
+    
     var sfSymbolId: SFSymbolId {
         switch self {
         case .bool:

--- a/Sources/Extensions/Value+Utilities.swift
+++ b/Sources/Extensions/Value+Utilities.swift
@@ -36,21 +36,6 @@ extension Value {
         }
     }
     
-    var toggleTypeDescription: String {
-        switch self {
-        case .bool:
-            return "Bool"
-        case .int:
-            return "Int"
-        case .number:
-            return "Double"
-        case .string:
-            return "String"
-        case .secure:
-            return "Secure"
-        }
-    }
-    
     var sfSymbolId: SFSymbolId {
         switch self {
         case .bool:

--- a/Sources/Providers/DefaultValueProvider.swift
+++ b/Sources/Providers/DefaultValueProvider.swift
@@ -25,4 +25,11 @@ final class DefaultValueProvider {
         }
         return value
     }
+    
+    func optionalValue(for variable: Variable) -> Value? {
+        guard let value = toggles[variable] else {
+            return nil
+        }
+        return value
+    }
 }

--- a/Sources/ToggleManager/ToggleManager.swift
+++ b/Sources/ToggleManager/ToggleManager.swift
@@ -70,18 +70,17 @@ extension ToggleManager {
     }
     
     private func fetchValueFromProviders(for variable: Variable) -> Value {
-        let defaultValue = defaultValueProvider.value(for: variable)
+        let defaultValue: Value? = defaultValueProvider.optionalValue(for: variable)
         
         if let value = mutableValueProvider?.value(for: variable), isValueValid(value: value, defaultValue: defaultValue) {
             return value
         }
-        
         for provider in valueProviders {
             if let value = provider.value(for: variable), isValueValid(value: value, defaultValue: defaultValue) {
                 return value
             }
         }
-        return defaultValue
+        return defaultValue!
     }
     
     private var shouldCheckInvalidSecureValues: Bool {
@@ -92,8 +91,8 @@ extension ToggleManager {
         return options.contains(.skipInvalidValueTypes)
     }
     
-    private func isValueValid(value: Value, defaultValue: Value) -> Bool {
-        if shouldCheckInvalidValueTypes, value.toggleTypeDescription != defaultValue.toggleTypeDescription {
+    private func isValueValid(value: Value, defaultValue: Value?) -> Bool {
+        if shouldCheckInvalidValueTypes, let defaultValue, value.toggleTypeDescription != defaultValue.toggleTypeDescription {
             return false
         }
         

--- a/Sources/ToggleManager/ToggleManager.swift
+++ b/Sources/ToggleManager/ToggleManager.swift
@@ -92,7 +92,7 @@ extension ToggleManager {
     }
     
     private func isValueValid(value: Value, defaultValue: Value?) -> Bool {
-        if shouldCheckInvalidValueTypes, let defaultValue, value.toggleTypeDescription != defaultValue.toggleTypeDescription {
+        if shouldCheckInvalidValueTypes, let defaultValue, !(value ~= defaultValue) {
             return false
         }
         

--- a/Tests/Suites/ToggleManager/ToggleManager+OptionsTests.swift
+++ b/Tests/Suites/ToggleManager/ToggleManager+OptionsTests.swift
@@ -12,185 +12,104 @@ final class ToggleManager_OptionsTests: XCTestCase {
         super.tearDown()
     }
     
-    //check fallback to default value when other value provider is different type
-    func test_fallbackToDefaultValueWhenOtherValueProviderIsADifferentType() throws {
+    func test_fallbackToDefaultValue_WhenOtherValueProviderValueIsADifferentType() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
         toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world"))], datasourceUrl: url, options: [.skipInvalidValueTypes])
         let variable = "integer_toggle"
         XCTAssertEqual(toggleManager.value(for: variable), Value.int(42))
     }
     
-    //check fallback to default when multiple value providers is different type
-    func test_fallbackToDefaultValueWhenMultipleOtherValueProviderAreDifferentTypes() throws {
+    func test_fallbackToDefaultValue_WhenMultipleOtherValueProviderValuesAreDifferentTypes() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
         toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world")), MockSingleValueProvider(value: .bool(true))], datasourceUrl: url, options: [.skipInvalidValueTypes])
         let variable = "integer_toggle"
         XCTAssertEqual(toggleManager.value(for: variable), Value.int(42))
     }
     
-    //check fallback to other valid value when only one value provider is different type
-    func test_fallbackToOtherValidValueWhenOneValueProviderIsADifferentType() throws {
+    func test_fallbackToOtherValidValue_WhenOneValueProviderValueIsADifferentType() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
         toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world")), MockSingleValueProvider(value: .int(333))], datasourceUrl: url, options: [.skipInvalidValueTypes])
         let variable = "integer_toggle"
         XCTAssertEqual(toggleManager.value(for: variable), Value.int(333))
     }
     
-    //check fallback to default value type when other one value provider has invalid secure value
-    func test_fallbackToDefaultValueWhenOtherValueProviderHasAnInvalidSecureValue() throws {
+    func test_fallbackToDefaultValue_WhenOtherValueProviderHasAnInvalidSecureValue() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
         toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .secure("my unencrypted string"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
+        
         let variable = "secure_toggle"
         let value = try toggleManager.readValue(for: .secure("YXe+Ev76FbdwCeDCVpZNZ1RItWZwKTLXF3/Yi+x62n3JWbvPo6YK"))
         XCTAssertEqual(toggleManager.value(for: variable), value)
     }
     
-    //check fallback to default value type when other in memory value provider has invalid secure value==========
-    func test_fallbackToDefaultValueWhenOtherInMemoryValueProviderHasAnInvalidSecureValue() throws {
+    func test_fallbackToDefaultValue_WhenInMemoryValueProviderHasAPresetInvalidSecureValue() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
         let variable = "secure_toggle"
         let inMemoryValueProvider = InMemoryValueProvider(datasource: [variable : .secure("my unencrypted string")])
+        
         toggleManager = try ToggleManager(mutableValueProvider: inMemoryValueProvider, datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
         
         let value = try toggleManager.readValue(for: .secure("YXe+Ev76FbdwCeDCVpZNZ1RItWZwKTLXF3/Yi+x62n3JWbvPo6YK"))
         XCTAssertEqual(toggleManager.value(for: variable), value)
     }
     
-    //check fallback to default value type when other in memory value provider has invalid secure value override==========
-    func test_fallbackToDefaultValueWhenOtherInMemoryValueProviderHasAnInvalidSecureValueOverride() throws {
+    func test_noFallbackToDefaultValueWhenInMemoryValueProviderHasASecureValueOverride() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
         let variable = "secure_toggle"
         let inMemoryValueProvider = InMemoryValueProvider()
         toggleManager = try ToggleManager(mutableValueProvider: inMemoryValueProvider, datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
         
-        toggleManager.set(.secure("my unencrypted string"), for: variable)
-        let value = try toggleManager.readValue(for: .secure("YXe+Ev76FbdwCeDCVpZNZ1RItWZwKTLXF3/Yi+x62n3JWbvPo6YK"))
+        toggleManager.set(.secure("hello world"), for: variable)
+        let value = try toggleManager.readValue(for: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))
         XCTAssertEqual(toggleManager.value(for: variable), value)
     }
     
-    //check fallback to other valid value when other value provider has invalid secure value
-    func test_fallbackToOtherSecureValueWhenOtherValueProviderHasAnInvalidSecureValue() throws {
+    func test_fallbackToOtherSecureValue_WhenOtherValueProviderHasAnInvalidSecureValue() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
-        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .secure("my unencrypted string")), MockSingleValueProvider(value: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .secure("my unencrypted string")), MockSingleValueProvider(value: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))],
+                                          datasourceUrl: url,
+                                          cipherConfiguration: CipherConfiguration.chaChaPoly,
+                                          options: [.skipInvalidSecureValues])
         let variable = "secure_toggle"
         let value = try toggleManager.readValue(for: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))
         XCTAssertEqual(toggleManager.value(for: variable), value)
     }
     
-    //check fallback to other valid value when other value provider has invalid secure value with in memory provider======
-    func test_fallbackToOtherSecureValueWhenOtherValueProviderHasAnInvalidSecureValueWithInMemoryProvider() throws {
+    func test_fallbackToOtherSecureValue_WhenInMemoryValueProviderHasAnInvalidSecureValue() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
         let variable = "secure_toggle"
         let inMemoryValueProvider = InMemoryValueProvider(datasource: [variable : .secure("my unencrypted string")])
         
-        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
+        toggleManager = try ToggleManager(mutableValueProvider: inMemoryValueProvider, valueProviders: [MockSingleValueProvider(value: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
         
         let value = try toggleManager.readValue(for: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))
         XCTAssertEqual(toggleManager.value(for: variable), value)
     }
     
-    //check fallback to default when multiple value providers has invalid secure value
-    func test_fallbackToDefaultValueWhenMultipleOtherValueProvidersHaveInvalidSecureValues() throws {
+    func test_fallbackToDefaultValue_WhenMultipleOtherValueProvidersHaveInvalidSecureValues() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
         toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .secure("my unencrypted string")), MockSingleValueProvider(value: .secure("hello world"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
+        
         let variable = "secure_toggle"
         let value = try toggleManager.readValue(for: .secure("YXe+Ev76FbdwCeDCVpZNZ1RItWZwKTLXF3/Yi+x62n3JWbvPo6YK"))
         XCTAssertEqual(toggleManager.value(for: variable), value)
     }
     
-    //check no fallback when there is no default value
     func test_noFallbackWhenValueProviderContainsValueNotInDefaultValueProvider() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
-        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world"))], datasourceUrl: url, options: [.skipInvalidValueTypes])
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("my new addition"))], datasourceUrl: url, options: [.skipInvalidValueTypes])
         let variable = "string_toggle_new"
-        XCTAssertEqual(toggleManager.value(for: variable), .string("hello world"))
+        XCTAssertEqual(toggleManager.value(for: variable), .string("my new addition"))
     }
     
-    
-    //check fallback with invalid secure, fallback with invalid type, no fallback with no default value
-    func test_fallbackWhenValueProvidersContainsInvalidSecureValueAndDifferentTypesAndNoFallBackWhenValueIsNotInDefaultValueProvider() throws {
+    func test_fallbackWhenValueProvidersContainsInvalidSecureValueAndDifferentTypes_AndNoFallBackWhenValueIsNotInDefaultValueProvider() throws {
         let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
         toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world")), MockSingleValueProvider(value: .secure("my unencrypted string"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidValueTypes, .skipInvalidSecureValues])
         let variableNotInDefaultProvider = "string_toggle_new"
-        let secureVariable = "secure_toggle"
         XCTAssertEqual(toggleManager.value(for: variableNotInDefaultProvider), .string("hello world"))
         
+        let secureVariable = "secure_toggle"
         let value = try toggleManager.readValue(for: .secure("YXe+Ev76FbdwCeDCVpZNZ1RItWZwKTLXF3/Yi+x62n3JWbvPo6YK"))
         XCTAssertEqual(toggleManager.value(for: secureVariable), value)
-    }
-    
-    // MARK: - DefaultValueProvider
-    
-    func test_value() throws {
-        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
-        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world"))], datasourceUrl: url)
-        let variable = "integer_toggle"
-        XCTAssertEqual(toggleManager.value(for: variable), Value.int(42))
-    }
-    
-    // MARK: - ValueProviders & DefaultValueProvider
-    
-    func test_valueWithValueProviders() throws {
-        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
-        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .int(42)),
-                                                           MockSingleValueProvider(value: .int(108))],
-                                          datasourceUrl: url)
-        let variable = "integer_toggle"
-        XCTAssertEqual(toggleManager.value(for: variable), Value.int(42))
-    }
-    
-    // MARK: - MutableValueProvider & DefaultValueProvider
-    
-    func test_valueWithMutableValueProvider() throws {
-        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
-        let variable = "integer_toggle"
-        let inMemoryValueProvider = InMemoryValueProvider(datasource: [variable : .int(420)])
-        toggleManager = try ToggleManager(mutableValueProvider: inMemoryValueProvider, datasourceUrl: url)
-        XCTAssertEqual(toggleManager.value(for: variable), Value.int(420))
-    }
-    
-    func test_valueOverrideWithMutableValueProvider() throws {
-        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
-        toggleManager = try ToggleManager(mutableValueProvider: InMemoryValueProvider(), datasourceUrl: url)
-        let variable = "integer_toggle"
-        toggleManager.set(.int(108), for: variable)
-        XCTAssertEqual(toggleManager.value(for: variable), Value.int(108))
-        toggleManager.delete(variable)
-    }
-    
-    func test_valueDeletionWithMutableValueProvider() throws {
-        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
-        toggleManager = try ToggleManager(mutableValueProvider: InMemoryValueProvider(), datasourceUrl: url)
-        let variable = "integer_toggle"
-        toggleManager.set(.int(108), for: variable)
-        toggleManager.delete(variable)
-        XCTAssertEqual(toggleManager.value(for: variable), Value.int(42))
-    }
-    
-    // MARK: - MutableValueProvider & ValueProviders & DefaultValueProvider
-    
-    func test_valueOverrideWithMutableValueProviderAndValueProvider() throws {
-        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
-        toggleManager = try ToggleManager(mutableValueProvider: InMemoryValueProvider(),
-                                          valueProviders: [MockSingleValueProvider(value: .int(108)),
-                                                           MockSingleValueProvider(value: .int(420))],
-                                          datasourceUrl: url)
-        let variable = "integer_toggle"
-        XCTAssertEqual(toggleManager.value(for: variable), Value.int(108))
-        toggleManager.set(.int(1000), for: variable)
-        XCTAssertEqual(toggleManager.value(for: variable), Value.int(1000))
-        toggleManager.delete(variable)
-    }
-    
-    func test_valueDeletionWithMutableValueProviderAndValueProvider() throws {
-        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
-        toggleManager = try ToggleManager(mutableValueProvider: InMemoryValueProvider(),
-                                          valueProviders: [MockSingleValueProvider(value: .int(108)),
-                                                           MockSingleValueProvider(value: .int(420))],
-                                          datasourceUrl: url)
-        let variable = "integer_toggle"
-        toggleManager.set(.int(1000), for: variable)
-        toggleManager.delete(variable)
-        XCTAssertEqual(toggleManager.value(for: variable), Value.int(108))
     }
 }

--- a/Tests/Suites/ToggleManager/ToggleManager+OptionsTests.swift
+++ b/Tests/Suites/ToggleManager/ToggleManager+OptionsTests.swift
@@ -1,0 +1,196 @@
+//  ToggleManager+OptionsTests.swift
+
+@testable import Toggles
+import XCTest
+
+final class ToggleManager_OptionsTests: XCTestCase {
+    private var toggleManager: ToggleManager!
+    
+    override func tearDown() {
+        toggleManager.removeOverrides()
+        toggleManager = nil
+        super.tearDown()
+    }
+    
+    //check fallback to default value when other value provider is different type
+    func test_fallbackToDefaultValueWhenOtherValueProviderIsADifferentType() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world"))], datasourceUrl: url, options: [.skipInvalidValueTypes])
+        let variable = "integer_toggle"
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(42))
+    }
+    
+    //check fallback to default when multiple value providers is different type
+    func test_fallbackToDefaultValueWhenMultipleOtherValueProviderAreDifferentTypes() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world")), MockSingleValueProvider(value: .bool(true))], datasourceUrl: url, options: [.skipInvalidValueTypes])
+        let variable = "integer_toggle"
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(42))
+    }
+    
+    //check fallback to other valid value when only one value provider is different type
+    func test_fallbackToOtherValidValueWhenOneValueProviderIsADifferentType() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world")), MockSingleValueProvider(value: .int(333))], datasourceUrl: url, options: [.skipInvalidValueTypes])
+        let variable = "integer_toggle"
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(333))
+    }
+    
+    //check fallback to default value type when other one value provider has invalid secure value
+    func test_fallbackToDefaultValueWhenOtherValueProviderHasAnInvalidSecureValue() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .secure("my unencrypted string"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
+        let variable = "secure_toggle"
+        let value = try toggleManager.readValue(for: .secure("YXe+Ev76FbdwCeDCVpZNZ1RItWZwKTLXF3/Yi+x62n3JWbvPo6YK"))
+        XCTAssertEqual(toggleManager.value(for: variable), value)
+    }
+    
+    //check fallback to default value type when other in memory value provider has invalid secure value==========
+    func test_fallbackToDefaultValueWhenOtherInMemoryValueProviderHasAnInvalidSecureValue() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        let variable = "secure_toggle"
+        let inMemoryValueProvider = InMemoryValueProvider(datasource: [variable : .secure("my unencrypted string")])
+        toggleManager = try ToggleManager(mutableValueProvider: inMemoryValueProvider, datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
+        
+        let value = try toggleManager.readValue(for: .secure("YXe+Ev76FbdwCeDCVpZNZ1RItWZwKTLXF3/Yi+x62n3JWbvPo6YK"))
+        XCTAssertEqual(toggleManager.value(for: variable), value)
+    }
+    
+    //check fallback to default value type when other in memory value provider has invalid secure value override==========
+    func test_fallbackToDefaultValueWhenOtherInMemoryValueProviderHasAnInvalidSecureValueOverride() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        let variable = "secure_toggle"
+        let inMemoryValueProvider = InMemoryValueProvider()
+        toggleManager = try ToggleManager(mutableValueProvider: inMemoryValueProvider, datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
+        
+        toggleManager.set(.secure("my unencrypted string"), for: variable)
+        let value = try toggleManager.readValue(for: .secure("YXe+Ev76FbdwCeDCVpZNZ1RItWZwKTLXF3/Yi+x62n3JWbvPo6YK"))
+        XCTAssertEqual(toggleManager.value(for: variable), value)
+    }
+    
+    //check fallback to other valid value when other value provider has invalid secure value
+    func test_fallbackToOtherSecureValueWhenOtherValueProviderHasAnInvalidSecureValue() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .secure("my unencrypted string")), MockSingleValueProvider(value: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
+        let variable = "secure_toggle"
+        let value = try toggleManager.readValue(for: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))
+        XCTAssertEqual(toggleManager.value(for: variable), value)
+    }
+    
+    //check fallback to other valid value when other value provider has invalid secure value with in memory provider======
+    func test_fallbackToOtherSecureValueWhenOtherValueProviderHasAnInvalidSecureValueWithInMemoryProvider() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        let variable = "secure_toggle"
+        let inMemoryValueProvider = InMemoryValueProvider(datasource: [variable : .secure("my unencrypted string")])
+        
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
+        
+        let value = try toggleManager.readValue(for: .secure("SwYDP6aCtI6L1jkJqE3vdzni/6V/CR9PDvpXG3bbF7t48iWyhjxx"))
+        XCTAssertEqual(toggleManager.value(for: variable), value)
+    }
+    
+    //check fallback to default when multiple value providers has invalid secure value
+    func test_fallbackToDefaultValueWhenMultipleOtherValueProvidersHaveInvalidSecureValues() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .secure("my unencrypted string")), MockSingleValueProvider(value: .secure("hello world"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidSecureValues])
+        let variable = "secure_toggle"
+        let value = try toggleManager.readValue(for: .secure("YXe+Ev76FbdwCeDCVpZNZ1RItWZwKTLXF3/Yi+x62n3JWbvPo6YK"))
+        XCTAssertEqual(toggleManager.value(for: variable), value)
+    }
+    
+    //check no fallback when there is no default value
+    func test_noFallbackWhenValueProviderContainsValueNotInDefaultValueProvider() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world"))], datasourceUrl: url, options: [.skipInvalidValueTypes])
+        let variable = "string_toggle_new"
+        XCTAssertEqual(toggleManager.value(for: variable), .string("hello world"))
+    }
+    
+    
+    //check fallback with invalid secure, fallback with invalid type, no fallback with no default value
+    func test_fallbackWhenValueProvidersContainsInvalidSecureValueAndDifferentTypesAndNoFallBackWhenValueIsNotInDefaultValueProvider() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world")), MockSingleValueProvider(value: .secure("my unencrypted string"))], datasourceUrl: url, cipherConfiguration: CipherConfiguration.chaChaPoly, options: [.skipInvalidValueTypes, .skipInvalidSecureValues])
+        let variableNotInDefaultProvider = "string_toggle_new"
+        let secureVariable = "secure_toggle"
+        XCTAssertEqual(toggleManager.value(for: variableNotInDefaultProvider), .string("hello world"))
+        
+        let value = try toggleManager.readValue(for: .secure("YXe+Ev76FbdwCeDCVpZNZ1RItWZwKTLXF3/Yi+x62n3JWbvPo6YK"))
+        XCTAssertEqual(toggleManager.value(for: secureVariable), value)
+    }
+    
+    // MARK: - DefaultValueProvider
+    
+    func test_value() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .string("hello world"))], datasourceUrl: url)
+        let variable = "integer_toggle"
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(42))
+    }
+    
+    // MARK: - ValueProviders & DefaultValueProvider
+    
+    func test_valueWithValueProviders() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(valueProviders: [MockSingleValueProvider(value: .int(42)),
+                                                           MockSingleValueProvider(value: .int(108))],
+                                          datasourceUrl: url)
+        let variable = "integer_toggle"
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(42))
+    }
+    
+    // MARK: - MutableValueProvider & DefaultValueProvider
+    
+    func test_valueWithMutableValueProvider() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        let variable = "integer_toggle"
+        let inMemoryValueProvider = InMemoryValueProvider(datasource: [variable : .int(420)])
+        toggleManager = try ToggleManager(mutableValueProvider: inMemoryValueProvider, datasourceUrl: url)
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(420))
+    }
+    
+    func test_valueOverrideWithMutableValueProvider() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(mutableValueProvider: InMemoryValueProvider(), datasourceUrl: url)
+        let variable = "integer_toggle"
+        toggleManager.set(.int(108), for: variable)
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(108))
+        toggleManager.delete(variable)
+    }
+    
+    func test_valueDeletionWithMutableValueProvider() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(mutableValueProvider: InMemoryValueProvider(), datasourceUrl: url)
+        let variable = "integer_toggle"
+        toggleManager.set(.int(108), for: variable)
+        toggleManager.delete(variable)
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(42))
+    }
+    
+    // MARK: - MutableValueProvider & ValueProviders & DefaultValueProvider
+    
+    func test_valueOverrideWithMutableValueProviderAndValueProvider() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(mutableValueProvider: InMemoryValueProvider(),
+                                          valueProviders: [MockSingleValueProvider(value: .int(108)),
+                                                           MockSingleValueProvider(value: .int(420))],
+                                          datasourceUrl: url)
+        let variable = "integer_toggle"
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(108))
+        toggleManager.set(.int(1000), for: variable)
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(1000))
+        toggleManager.delete(variable)
+    }
+    
+    func test_valueDeletionWithMutableValueProviderAndValueProvider() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        toggleManager = try ToggleManager(mutableValueProvider: InMemoryValueProvider(),
+                                          valueProviders: [MockSingleValueProvider(value: .int(108)),
+                                                           MockSingleValueProvider(value: .int(420))],
+                                          datasourceUrl: url)
+        let variable = "integer_toggle"
+        toggleManager.set(.int(1000), for: variable)
+        toggleManager.delete(variable)
+        XCTAssertEqual(toggleManager.value(for: variable), Value.int(108))
+    }
+}


### PR DESCRIPTION
A couple scenarios here which I have added functionality for Toggles to handle.

`.skipInvalidSecureValues`
Someone sets an invalid secure value via one of the value providers (a value which cannot be decrypted) then this value will be skipped and Toggles will search for another secure value in the other value providers. Whilst maintaining the same order of cycling through the value providers.

An example of this might be someone setting a value that is supposed to be encrypted via an experimentation platform. If Toggles cannot decrypt this value, it will fallback to another value provider's value (if one has been set).


`.skipInvalidValueTypes`
Someone sets a value of a different type via one of the value providers that doesn't match the original type in the DefaultValueProvider (your local .json file) then this value will be skipped and Toggles will search for another value in the other value providers. Falling back to the local .json file if necessary. Whilst maintaining the same order of cycling through the value providers.

Both these options make it more stable if you are using a value provider which could be volatile. It can prevent crashes if you have configured your app using ToggleGen where every value in Toggles.json (the original flagging file) is force unwrapped. - Since it will fallback to the value from Toggles.json or another value provider of lower priority.

Note: 

- `.skipInvalidValueTypes` will not skip or attempt to compare a variable if it is not in the DefaultValueProvider. (So if a new variable is set via another value provider, it will pass through without any issues)
- `.skipInvalidSecureValues` ToggleManager will find nil if a value provider sets an invalid secure value and there is no fallback values in other providers.

Also I did initially consider modifying the decrypt function where if a flag like `.gracefullyIgnoreInvalidSecureValues` was set, it would return `""` for an invalid secure value, but this would of meant TogglesManager wouldn't fallback to valid secure values which maybe in other providers (safe default values like what should be in the DefaultValueProvider).
