### PR TITLE
Toggle detail view bug fix

### DIFF
--- a/Sources/Providers/DefaultValueProvider.swift
+++ b/Sources/Providers/DefaultValueProvider.swift
@@ -4,15 +4,16 @@ import Foundation
 
 final class DefaultValueProvider {
     
-    var name: String = "Default"
+    let name: String
     
     private let toggles: [Variable: Value]
     
-    init(jsonURL: URL) throws {
+    init(name: String = "Default", jsonURL: URL) throws {
         let content = try Data(contentsOf: jsonURL)
         let datasource = try JSONDecoder().decode(Datasource.self, from: content)
         let groupedToggles = Dictionary(grouping: datasource.toggles, by: \.variable)
         try TogglesValidator.validate(groupedToggles)
+        self.name = name
         self.toggles = groupedToggles
             .mapValues { $0.first! }
             .mapValues { $0.value }

--- a/Sources/Providers/InMemoryValueProvider.swift
+++ b/Sources/Providers/InMemoryValueProvider.swift
@@ -6,14 +6,15 @@ import Foundation
 /// Alterations to toggles are not persisted.
 final public class InMemoryValueProvider {
     
-    public var name: String = "InMemory"
+    public let name: String
     
     private var storage: [Variable: Value]
     
     /// The default initializer.
     ///
     /// - Parameter datasource: The toggles datasource in the form of dictionary of `Variable`s and `Value`s.
-    public init(datasource: [Variable: Value] = [Variable: Value]()) {
+    public init(name: String = "InMemory", datasource: [Variable: Value] = [Variable: Value]()) {
+        self.name = name
         self.storage = datasource
     }
 }

--- a/Sources/Providers/LocalValueProvider.swift
+++ b/Sources/Providers/LocalValueProvider.swift
@@ -5,18 +5,19 @@ import Foundation
 /// Value provider with a local datasource.
 final public class LocalValueProvider {
     
-    public var name: String = "Local"
+    public let name: String
     
     private let toggles: [Variable: Value]
     
     /// The default initializer.
     ///
     /// - Parameter jsonUrl: The url to the file containing the toggles.
-    public init(jsonUrl: URL) throws {
+    public init(name: String = "Local", jsonUrl: URL) throws {
         let content = try Data(contentsOf: jsonUrl)
         let datasource = try JSONDecoder().decode(Datasource.self, from: content)
         let groupedToggles = Dictionary(grouping: datasource.toggles, by: \.variable)
         try TogglesValidator.validate(groupedToggles)
+        self.name = name
         self.toggles = groupedToggles
             .mapValues { $0.first! }
             .mapValues { $0.value }

--- a/Sources/Providers/PersistentValueProvider.swift
+++ b/Sources/Providers/PersistentValueProvider.swift
@@ -8,14 +8,15 @@ private let userDefaultsKeyPrefix = "com.toggles"
 /// Alterations to toggles are therefore persisted across app restarts and updates.
 final public class PersistentValueProvider {
     
-    public var name: String = "Persistent"
+    public let name: String
     
     private let userDefaults: UserDefaults
     
     /// The default initializer.
     ///
     /// - Parameter userDefaults: The user defaults to store the toggles to.
-    public init(userDefaults: UserDefaults) {
+    public init(name: String = "Persistent", userDefaults: UserDefaults) {
+        self.name = name
         self.userDefaults = userDefaults
     }
 }

--- a/Sources/ToggleManager/ToggleManager+Trace.swift
+++ b/Sources/ToggleManager/ToggleManager+Trace.swift
@@ -7,7 +7,7 @@ extension ToggleManager {
     typealias ProviderName = String
     
     struct Trace: Equatable, Identifiable {
-        var id: String { providerName }
+        let id = UUID()
         let providerName: ProviderName
         let value: Value?
     }

--- a/Tests/Suites/ToggleManager/ToggleManager+TraceTests.swift
+++ b/Tests/Suites/ToggleManager/ToggleManager+TraceTests.swift
@@ -18,19 +18,19 @@ final class ToggleManager_TraceTests: XCTestCase {
         let trace = toggleManager.stackTrace(for: variable)
         
         let inMemory = trace[0]
-        XCTAssertEqual(inMemory.id, "InMemory")
-        XCTAssertEqual(inMemory, ToggleManager.Trace(providerName: "InMemory", value: .int(1)))
+        XCTAssertEqual(inMemory.providerName, "InMemory")
+        XCTAssertEqual(inMemory.value, .int(1))
         
         let mock1 = trace[1]
-        XCTAssertEqual(mock1.id, "SingleValue (mock)")
-        XCTAssertEqual(mock1, ToggleManager.Trace(providerName: "SingleValue (mock)", value: .int(104)))
+        XCTAssertEqual(mock1.providerName, "SingleValue (mock)")
+        XCTAssertEqual(mock1.value, .int(104))
         
         let mock2 = trace[2]
-        XCTAssertEqual(mock2.id, "SingleValue (mock)")
-        XCTAssertEqual(mock2, ToggleManager.Trace(providerName: "SingleValue (mock)", value: .int(108)))
+        XCTAssertEqual(mock2.providerName, "SingleValue (mock)")
+        XCTAssertEqual(mock2.value, .int(108))
         
         let `default` = trace[3]
-        XCTAssertEqual(`default`.id, "Default")
-        XCTAssertEqual(`default`, ToggleManager.Trace(providerName: "Default", value: .int(42)))
+        XCTAssertEqual(`default`.providerName, "Default")
+        XCTAssertEqual(`default`.value, .int(42))
     }
 }


### PR DESCRIPTION
## Summary

Even though the retrieved values are correct, we observed some odd behaviour in the `ToggleView` while migrating our app to Toggles.

After investigation, I discovered the issue happens because we have two `LocalValueProvider`. One is for debug builds only, and the second is for all builds.

On debug builds, the `ToggleView` wouldn't show the correct values for local providers. For instance, it would show that a value was nil on both providers even though it was set in one of them.

It turns out this is a bug in the SwiftUI view itself. The `ForEach` loop that creates the sections of providers is looping through each `stackTrace(for: toggle.variable)`. The `Trace` object is identifiable, but the value used for the `id` property is the `providerName`. When two providers have the same name (i.e. `Local`), it's conflicting and SwiftUI shows two identical cells in the UI.

## Changes

In this pull request, I updated the `Trace` object to use `UUID` as an identifier to ensure each cell is unique in the UI.
I also updated the providers so we can easily set their names in the `init`. They will still have default values as before.

## Attachments

Here is an example of the bug with two local providers. One has the value set, and the other does not. The screenshot before the bug fix shows that the UI was wrongly displaying that both providers didn't have the value set.

| Before | After |
|--|--|
|![Simulator Screenshot - iPhone 14 Pro - 2023-12-18 at 17 00 00](https://github.com/TogglesPlatform/Toggles/assets/6460866/766c1853-173b-4bbf-a538-3d5e3a2b00dc)|![Simulator Screenshot - iPhone 14 Pro - 2023-12-18 at 17 00 19](https://github.com/TogglesPlatform/Toggles/assets/6460866/e4bae88a-f962-48dc-8b9f-59c1cf21f4d8)|

