### PR TITLE
Clear Cache Function

### DIFF
--- a/Sources/ToggleManager/ToggleManager+Caching.swift
+++ b/Sources/ToggleManager/ToggleManager+Caching.swift
@@ -9,4 +9,10 @@ extension ToggleManager {
             cache[variable]
         }
     }
+    
+    public func clearCache() {
+        queue.sync(flags: .barrier) {
+            do { cache.evict() }
+        }
+    }
 }

--- a/Tests/Suites/ToggleManager/ToggleManager+CachingTests.swift
+++ b/Tests/Suites/ToggleManager/ToggleManager+CachingTests.swift
@@ -23,4 +23,15 @@ final class ToggleManager_CachingTests: XCTestCase {
         toggleManager.set(.int(42), for: variable)
         XCTAssertNotNil(toggleManager.getCachedValue(for: variable))
     }
+    
+    func test_cacheIsClearedAfterSet() throws {
+        let toggleManager = try ToggleManager(mutableValueProvider: InMemoryValueProvider(),
+                                              datasourceUrl: url)
+        let variable = "integer_toggle"
+        XCTAssertNil(toggleManager.getCachedValue(for: variable))
+        toggleManager.set(.int(42), for: variable)
+        XCTAssertNotNil(toggleManager.getCachedValue(for: variable))
+        toggleManager.clearCache()
+        XCTAssertNil(toggleManager.getCachedValue(for: variable))
+    }
 }


### PR DESCRIPTION
Added a simple function to clear the `ToggleManager` cache to free up memory if needed.

The difference between this and `removeOverrides()` is `clearCache()` wont clear any overridden values / values set via the `MutableValueProvider`. 