### PR TITLE
Expose variables from the `LocalValueProvider`

### DIFF
--- a/Sources/Providers/DefaultValueProvider.swift
+++ b/Sources/Providers/DefaultValueProvider.swift
@@ -6,7 +6,7 @@ final class DefaultValueProvider {
     
     let name: String
     
-    let toggles: [Variable: Value]
+    private let toggles: [Variable: Value]
     
     init(name: String = "Default", jsonURL: URL) throws {
         let content = try Data(contentsOf: jsonURL)

--- a/Sources/Providers/DefaultValueProvider.swift
+++ b/Sources/Providers/DefaultValueProvider.swift
@@ -6,7 +6,7 @@ final class DefaultValueProvider {
     
     let name: String
     
-    private let toggles: [Variable: Value]
+    let toggles: [Variable: Value]
     
     init(name: String = "Default", jsonURL: URL) throws {
         let content = try Data(contentsOf: jsonURL)

--- a/Sources/Providers/LocalValueProvider.swift
+++ b/Sources/Providers/LocalValueProvider.swift
@@ -7,7 +7,11 @@ final public class LocalValueProvider {
     
     public let name: String
     
-    let toggles: [Variable: Value]
+    private let toggles: [Variable: Value]
+    
+    public var variables: [Variable] {
+        toggles.map(\.key)
+    }
     
     /// The default initializer.
     ///

--- a/Sources/Providers/LocalValueProvider.swift
+++ b/Sources/Providers/LocalValueProvider.swift
@@ -7,7 +7,7 @@ final public class LocalValueProvider {
     
     public let name: String
     
-    private let toggles: [Variable: Value]
+    let toggles: [Variable: Value]
     
     /// The default initializer.
     ///

--- a/Tests/Suites/Providers/LocalValueProviderTests.swift
+++ b/Tests/Suites/Providers/LocalValueProviderTests.swift
@@ -29,4 +29,12 @@ final class LocalValueProviderTests: XCTestCase {
             XCTAssertEqual(error as! TogglesValidator.LoaderError, TogglesValidator.LoaderError.foundDuplicateVariables(["boolean_toggle", "integer_toggle"]))
         }
     }
+    
+    func test_variables() throws {
+        let url = Bundle.toggles.url(forResource: "TestDatasource", withExtension: "json")!
+        let provider = try LocalValueProvider(jsonUrl: url)
+        for variable in provider.variables {
+            XCTAssertNotNil(provider.value(for: variable))
+        }
+    }
 }


### PR DESCRIPTION
## Summary

~~This PR makes `toggles` internal in `DefaultValueProvider` & `LocalValueProvider`. 
This change is needed so the property can be accessed when using `@testable import` to iterate over all toggles for testing purposes.~~

As discussed, I updated the PR only to expose variables from `LocalValueProvider`. This is enough to iterate through each value (whether it's for testing purposes).