### PR TITLE
Implement `publish_release` release workflow

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,0 +1,32 @@
+name: Create release
+
+inputs:
+  gh-token:
+    description: A token to perform REST API calls to GitHub
+    required: true
+  repository:
+    description: The repository name including the org
+    required: true
+  tag-name:
+    description: The tag to use for the release
+    required: true
+
+outputs:
+  release-id:
+    description: The ID of the release
+    value: ${{ steps.create-release.outputs.release_id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create release
+      id: create-release
+      shell: bash
+      run: |
+        RELEASE_ID=`curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ inputs.gh-token }}" \
+          "https://api.github.com/repos/${{ inputs.repository }}/releases" \
+          -d '{"tag_name":"${{ inputs.tag-name }}","generate_release_notes":true}' | jq -r '.id'`
+        echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"

--- a/.github/actions/create-universal-binary/action.yml
+++ b/.github/actions/create-universal-binary/action.yml
@@ -1,0 +1,53 @@
+name: Create universal binary
+
+inputs:
+  tool-name:
+    description: The name of the tool
+    required: true
+
+outputs:
+  zip-filename:
+    description: The filename of the generated .zip
+    value: ${{ steps.zip-universal-binary.outputs.zip_filename }}
+  zip-path:
+    description: The path to .zip containing the universal binary
+    value: ${{ steps.zip-universal-binary.outputs.zip_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create tmp/universal-binary folder
+      shell: bash
+      run: rm -rf tmp/universal-binary && mkdir -p tmp/universal-binary
+    - name: Delete build artifacts
+      shell: bash
+      run: swift package clean
+    - name: Build binary (arm64)
+      shell: bash
+      working-directory: ./${{ inputs.tool-name }}
+      run: swift build -c release --arch arm64
+    - name: Build binary (x86_64)
+      shell: bash
+      working-directory: ./${{ inputs.tool-name }}
+      run: swift build -c release --arch x86_64
+    - name: Create universal binary
+      shell: bash
+      working-directory: ./${{ inputs.tool-name }}
+      run: |
+        lipo -create -output \
+          ${{ inputs.tool-name }} .build/arm64-apple-macosx/release/${{ inputs.tool-name }} \
+          .build/x86_64-apple-macosx/release/${{ inputs.tool-name }}
+    - name: Move universal binary to tmp/universal-binary folder
+      shell: bash
+      run: |
+        mv ${{ inputs.tool-name }} tmp/universal-binary/${{ inputs.tool-name }}
+    - name: Zip universal binary
+      id: zip-universal-binary
+      shell: bash
+      working-directory: tmp/universal-binary
+      run: |
+        zip -r ${{ env.ZIP_FILE }} ${{ inputs.tool-name }}/${{ inputs.tool-name }}
+        echo "zip_filename=${{ env.ZIP_FILE }}" >> $GITHUB_OUTPUT
+        echo "zip_path=tmp/universal-binary/${{ env.ZIP_FILE }}" >> $GITHUB_OUTPUT
+      env:
+        ZIP_FILE: ${{ inputs.tool-name }}-macOS-universal-binary.zip

--- a/.github/actions/upload-release-asset/action.yml
+++ b/.github/actions/upload-release-asset/action.yml
@@ -1,0 +1,40 @@
+name: Upload release asset
+
+inputs:
+  asset-filename:
+    description: The filename of the asset to upload
+    required: true
+  asset-path:
+    description: The local path to the asset to upload
+    required: true
+  gh-token:
+    description: A token to perform REST API calls to GitHub
+    required: true
+  repository:
+    description: The repository name including the org
+    required: true
+  release-id:
+    description: The ID of the release
+    required: true
+
+outputs:
+  zip-filename:
+    description: "Filename of the generated .zip"
+    value: ${{ steps.zip-fat-binary.outputs.zip_filename }}
+  zip-path:
+    description: "Path to .zip containing fat binary"
+    value: ${{ steps.zip-fat-binary.outputs.zip_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Upload release asset (${{ inputs.asset-path }})
+      shell: bash
+      run: |
+        curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ inputs.gh-token }}" \
+          -H "Content-Type: application/octet-stream" \
+          "https://uploads.github.com/repos/${{ inputs.repository }}/releases/${{ inputs.release-id }}/assets?name=${{ inputs.asset-filename }}" \
+          --data-binary "@${{ inputs.asset-path }}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,67 @@
+name: Publish Release ${{ github.ref_name }}
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  XCODE_VERSION: 14.0.1
+
+jobs:
+  publish-release:
+    name: Publish release ${{ github.ref_name }}
+    runs-on: macos-13
+    steps:
+    - name: Switch xcode to ${{ env.XCODE_VERSION }}
+      run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+    - name: Show macOS version (${{ env.XCODE_VERSION }})
+      run: sw_vers
+    - name: Code Checkout
+      uses: actions/checkout@v2
+    - name: Create release
+      id: create-release
+      uses: ./.github/actions/create-release
+      with:
+        gh-token: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.repository }}
+        tag-name: ${{ github.ref_name }}
+    - name: Create universal binary (ToggleGen)
+      id: create-universal-binary-ToggleGen
+      uses: ./.github/actions/create-universal-binary
+      with:
+        tool-name: ToggleGen
+    - name: Upload universal binary (ToggleGen)
+      uses: ./.github/actions/upload-release-asset
+      with:
+        asset-filename: ${{ steps.create-universal-binary-ToggleGen.outputs.zip-filename }}
+        asset-path: ${{ steps.create-universal-binary-ToggleGen.outputs.zip-path }}
+        gh-token: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.repository }}
+        release-id: ${{ steps.create-release.outputs.release-id }}
+    - name: Create universal binary (ToggleCipher)
+      id: create-universal-binary-ToggleCipher
+      uses: ./.github/actions/create-universal-binary
+      with:
+        tool-name: ToggleCipher
+    - name: Upload universal binary (ToggleCipher)
+      uses: ./.github/actions/upload-release-asset
+      with:
+        asset-filename: ${{ steps.create-universal-binary-ToggleCipher.outputs.zip-filename }}
+        asset-path: ${{ steps.create-universal-binary-ToggleCipher.outputs.zip-path }}
+        gh-token: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.repository }}
+        release-id: ${{ steps.create-release.outputs.release-id }}
+    - name: Create universal binary (JustTweakMigrator)
+      id: create-universal-binary-JustTweakMigrator
+      uses: ./.github/actions/create-universal-binary
+      with:
+        tool-name: JustTweakMigrator
+    - name: Upload universal binary (JustTweakMigrator)
+      uses: ./.github/actions/upload-release-asset
+      with:
+        asset-filename: ${{ steps.create-universal-binary-JustTweakMigrator.outputs.zip-filename }}
+        asset-path: ${{ steps.create-universal-binary-JustTweakMigrator.outputs.zip-path }}
+        gh-token: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.repository }}
+        release-id: ${{ steps.create-release.outputs.release-id }}


### PR DESCRIPTION
Upon pushing a tag, a new release on GitHub gets created with assets of the universal binaries.