### PR TITLE
Fix `ToggleObservable` memory leak

### DIFF
--- a/Sources/ObservableObjects/ToggleObservable.swift
+++ b/Sources/ObservableObjects/ToggleObservable.swift
@@ -44,9 +44,14 @@ public class ToggleObservable: ObservableObject {
         subscribe(on: variable)
     }
     
+    deinit {
+        cancellables.removeAll()
+    }
+    
     private func subscribe(on variable: Variable) {
         manager.publisher(for: variable)
-            .sink { value in
+            .sink { [weak self] value in
+                guard let self else { return }
                 self.value = value
                 switch value {
                 case .bool(let value):


### PR DESCRIPTION
Have been playing with Demo app and realised there is a memory leak in `ToggleObservable`. It is 100% reproducible if you try to override the any Toggle value. 

Instruments|Memory Debugger
-|-
<img src='https://github.com/TogglesPlatform/Toggles/assets/9494262/550c484c-b21a-41cd-9f6f-b9c91201c80c' width='200'>|<img src='https://github.com/TogglesPlatform/Toggles/assets/9494262/396a242c-0e39-4649-a40d-079d9599d084' width='200'>

Fix is quite straightforward, adding `weak self` as `ToggleObservable` is a reference type. Also added the `deinit` where I remove every publisher stored in `cancellables`. Its an extra safety for any potential future memory leaks.