### PR TITLE
Introduce `Object` and `ObjectSupportedType`

### DIFF
--- a/Sources/Extensions/Object+Decodable.swift
+++ b/Sources/Extensions/Object+Decodable.swift
@@ -1,0 +1,26 @@
+//  Object+Decodable.swift
+
+import Foundation
+
+extension Object: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if let dictionary = try? container.decode([Variable: ObjectSupportedType].self) {
+            var map = [Variable: ObjectSupportedType]()
+            for (key, item) in dictionary {
+                guard !key.isEmpty else {
+                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "JSON contained empty key. Invalid data.")
+                }
+                map[key] = item
+            }
+            if map.isEmpty {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Empty object. Invalid data.")
+            }
+            
+            self.map = map
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported type. Invalid data.")
+        }
+    }
+}

--- a/Sources/Extensions/ObjectSupportedType+Accessors.swift
+++ b/Sources/Extensions/ObjectSupportedType+Accessors.swift
@@ -1,0 +1,30 @@
+//  ObjectSupportedType+Accessors.swift
+
+import Foundation
+
+public extension ObjectSupportedType {
+    /// The raw value of the `Object`'s property, if it's of boolean type, nil otherwise.
+    var boolValue: Bool? {
+        guard case let .bool(v) = self else { return nil }
+        return v
+    }
+
+    /// The raw value of the `Object`'s property, if it's of integer type, nil otherwise.
+    var intValue: Int? {
+        guard case let .int(v) = self else { return nil }
+        return v
+    }
+
+    /// The raw value of the `Object`'s property, if it's of number type, nil otherwise.
+    var numberValue: Double? {
+        guard case let .number(v) = self else { return nil }
+        return v
+    }
+    
+    /// The raw value of the `Object`'s property, if it's of string type, nil otherwise.
+    var stringValue: String? {
+        guard case let .string(v) = self else { return nil }
+        return v
+    }
+}
+

--- a/Sources/Extensions/ObjectSupportedType+Decodable.swift
+++ b/Sources/Extensions/ObjectSupportedType+Decodable.swift
@@ -1,0 +1,21 @@
+//  ObjectSupportedType+Decodable.swift
+
+import Foundation
+
+extension ObjectSupportedType: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self = .int(int)
+        } else if let number = try? container.decode(Double.self) {
+            self = .number(number)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "ObjectSupportedType tried to decode unsupported type, could not decode")
+        }
+    }
+}

--- a/Sources/Extensions/ObjectSupportedType+Utilities.swift
+++ b/Sources/Extensions/ObjectSupportedType+Utilities.swift
@@ -1,0 +1,23 @@
+//  ObjectSupportedType+Utilities.swift
+
+import Foundation
+
+extension ObjectSupportedType {
+    var anyValue: Any {
+        switch self {
+        case .bool(let bool): return bool
+        case .int(let int): return int
+        case .string(let string): return string
+        case .number(let number): return number
+        }
+    }
+}
+
+extension Dictionary where Value == ObjectSupportedType {
+    var anyValue: [Key: Any] {
+        reduce(into: [:], { result, next in
+            result[next.key] = next.value.anyValue
+        })
+    }
+}
+

--- a/Sources/Models/Object.swift
+++ b/Sources/Models/Object.swift
@@ -4,42 +4,13 @@ import Foundation
 
 /// Model representing object value for a Toggle.
 /// It container to access a object as a dictionary or a concrete type `T`
-public class Object: Codable {
+public struct Object {
     public let map: [Variable: ObjectSupportedType]
-    
-    required public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        
-        if let dictionary = try? container.decode([Variable: ObjectSupportedType].self) {
-            var map = [Variable: ObjectSupportedType]()
-            for (key, item) in dictionary {
-                guard !key.isEmpty else {
-                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "JSON contained empty key. Invalid data.")
-                }
-                map[key] = item
-            }
-            if map.isEmpty {
-                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Empty object. Invalid data.")
-            }
-            
-            self.map = map
-        } else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported type. Invalid data.")
-        }
-    }
     
     /// Generic function to decode Object into type `T` which must conform ``Decodable``.
     /// - Returns: Returns object T. If value can not be decoded into object T it throws Decoding exception.
     public func asType<T: Decodable>() throws -> T {
         let data = try JSONSerialization.data(withJSONObject: map.anyValue, options: [])
         return try JSONDecoder().decode(T.self, from: data)
-    }
-}
-
-extension Dictionary where Value == ObjectSupportedType {
-    var anyValue: [Key: Any] {
-        reduce(into: [:], { result, next in
-            result[next.key] = next.value.anyValue
-        })
     }
 }

--- a/Sources/Models/Object.swift
+++ b/Sources/Models/Object.swift
@@ -1,0 +1,45 @@
+//  Object.swift
+
+import Foundation
+
+/// Model representing object value for a Toggle.
+/// It container to access a object as a dictionary or a concrete type `T`
+public class Object: Codable {
+    public let map: [Variable: ObjectSupportedType]
+    
+    required public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if let dictionary = try? container.decode([Variable: ObjectSupportedType].self) {
+            var map = [Variable: ObjectSupportedType]()
+            for (key, item) in dictionary {
+                guard !key.isEmpty else {
+                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "JSON contained empty key. Invalid data.")
+                }
+                map[key] = item
+            }
+            if map.isEmpty {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Empty object. Invalid data.")
+            }
+            
+            self.map = map
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported type. Invalid data.")
+        }
+    }
+    
+    /// Generic function to decode Object into type `T` which must conform ``Decodable``.
+    /// - Returns: Returns object T. If value can not be decoded into object T it throws Decoding exception.
+    public func asType<T: Decodable>() throws -> T {
+        let data = try JSONSerialization.data(withJSONObject: map.anyValue, options: [])
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}
+
+extension Dictionary where Value == ObjectSupportedType {
+    var anyValue: [Key: Any] {
+        reduce(into: [:], { result, next in
+            result[next.key] = next.value.anyValue
+        })
+    }
+}

--- a/Sources/Models/ObjectSupportedType.swift
+++ b/Sources/Models/ObjectSupportedType.swift
@@ -3,62 +3,9 @@
 import Foundation
 
 /// Supported types for `Object`
-public enum ObjectSupportedType: Codable {
+public enum ObjectSupportedType {
     case bool(Bool)
     case int(Int)
     case number(Double)
     case string(String)
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-
-        if let bool = try? container.decode(Bool.self) {
-            self = .bool(bool)
-        } else if let int = try? container.decode(Int.self) {
-            self = .int(int)
-        } else if let number = try? container.decode(Double.self) {
-            self = .number(number)
-        } else if let string = try? container.decode(String.self) {
-            self = .string(string)
-        } else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "ObjectSupportedType tried to decode unsupported type, could not decode")
-        }
-    }
-}
-
-public extension ObjectSupportedType {
-    /// The raw value of the `Object`'s property, if it's of boolean type, nil otherwise.
-    var boolValue: Bool? {
-        guard case let .bool(v) = self else { return nil }
-        return v
-    }
-
-    /// The raw value of the `Object`'s property, if it's of integer type, nil otherwise.
-    var intValue: Int? {
-        guard case let .int(v) = self else { return nil }
-        return v
-    }
-
-    /// The raw value of the `Object`'s property, if it's of number type, nil otherwise.
-    var numberValue: Double? {
-        guard case let .number(v) = self else { return nil }
-        return v
-    }
-    
-    /// The raw value of the `Object`'s property, if it's of string type, nil otherwise.
-    var stringValue: String? {
-        guard case let .string(v) = self else { return nil }
-        return v
-    }
-}
-
-extension ObjectSupportedType {
-    var anyValue: Any {
-        switch self {
-        case .bool(let bool): return bool
-        case .int(let int): return int
-        case .string(let string): return string
-        case .number(let number): return number
-        }
-    }
 }

--- a/Sources/Models/ObjectSupportedType.swift
+++ b/Sources/Models/ObjectSupportedType.swift
@@ -1,0 +1,64 @@
+//  ObjectSupportedType.swift
+
+import Foundation
+
+/// Supported types for `Object`
+public enum ObjectSupportedType: Codable {
+    case bool(Bool)
+    case int(Int)
+    case number(Double)
+    case string(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self = .int(int)
+        } else if let number = try? container.decode(Double.self) {
+            self = .number(number)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "ObjectSupportedType tried to decode unsupported type, could not decode")
+        }
+    }
+}
+
+public extension ObjectSupportedType {
+    /// The raw value of the `Object`'s property, if it's of boolean type, nil otherwise.
+    var boolValue: Bool? {
+        guard case let .bool(v) = self else { return nil }
+        return v
+    }
+
+    /// The raw value of the `Object`'s property, if it's of integer type, nil otherwise.
+    var intValue: Int? {
+        guard case let .int(v) = self else { return nil }
+        return v
+    }
+
+    /// The raw value of the `Object`'s property, if it's of number type, nil otherwise.
+    var numberValue: Double? {
+        guard case let .number(v) = self else { return nil }
+        return v
+    }
+    
+    /// The raw value of the `Object`'s property, if it's of string type, nil otherwise.
+    var stringValue: String? {
+        guard case let .string(v) = self else { return nil }
+        return v
+    }
+}
+
+extension ObjectSupportedType {
+    var anyValue: Any {
+        switch self {
+        case .bool(let bool): return bool
+        case .int(let int): return int
+        case .string(let string): return string
+        case .number(let number): return number
+        }
+    }
+}

--- a/Tests/Suites/Models/ObjectTests.swift
+++ b/Tests/Suites/Models/ObjectTests.swift
@@ -1,0 +1,102 @@
+//  ObjectTests.swift
+
+import XCTest
+@testable import Toggles
+
+final class ObjectTests: XCTestCase {
+    func test_objectDecoding_withSupportedTypes() throws {
+        let jsonString = """
+        {
+          "boolProperty": false,
+          "intProperty": 420,
+          "stringProperty": "mild",
+          "doubleProperty": 13.5
+        }
+        """
+        
+        let object = try XCTUnwrap(decodeJSON(jsonString))
+        let dictionary = object.map
+        
+        XCTAssertEqual(dictionary["boolProperty"]?.boolValue, false)
+        XCTAssertEqual(dictionary["intProperty"]?.intValue, 420)
+        XCTAssertEqual(dictionary["stringProperty"]?.stringValue, "mild")
+        XCTAssertEqual(dictionary["doubleProperty"]?.numberValue, 13.5)
+    }
+    
+    func test_objectDecoding_asType_withSupportedTypes_succeeds() throws {
+        let jsonString = """
+        {
+          "boolProperty": false,
+          "intProperty": 420,
+          "stringProperty": "mild",
+          "doubleProperty": 13.5
+        }
+        """
+        
+        let object = try XCTUnwrap(decodeJSON(jsonString))
+        
+        struct MyObject: Codable {
+            let boolProperty: Bool
+            let intProperty: Int
+            let stringProperty: String
+            let doubleProperty: Double
+        }
+        
+        let myObject: MyObject = try XCTUnwrap(try object.asType())
+        
+        XCTAssertEqual(myObject.boolProperty, false)
+        XCTAssertEqual(myObject.intProperty, 420)
+        XCTAssertEqual(myObject.stringProperty, "mild")
+        XCTAssertEqual(myObject.doubleProperty, 13.5)
+    }
+    
+    func test_objectDecoding_withUnsupportedTypes_throws() throws {
+        let jsonString = "{\"arrayProperty\": [false, true]}"
+        
+        XCTAssertThrowsError(try decodeJSON(jsonString)) { error in
+            XCTAssertEqual(error is DecodingError, true)
+        }
+    }
+    
+    func test_objectDecoding_asType_withNotMatchedObject_throws() throws {
+        let jsonString = "{\"boolProperty\": false}"
+        
+        let object = try XCTUnwrap(decodeJSON(jsonString))
+        
+        struct MyObject: Codable {
+            let stringProperty: String
+        }
+        
+        var myObject: MyObject?
+        XCTAssertThrowsError(
+            myObject = try object.asType()
+        ) { error in
+            XCTAssertNil(myObject)
+            XCTAssertEqual(error is DecodingError, true)
+        }
+    }
+    
+    func test_objectDecoding_withEmptyKey_throws() throws {
+        let jsonString = "{\"\": false}"
+        
+        XCTAssertThrowsError(try decodeJSON(jsonString)) { error in
+            XCTAssertEqual(error is DecodingError, true)
+        }
+    }
+    
+    func test_emptyObjectDecoding_throws() throws {
+        let jsonString = "{}"
+        
+        XCTAssertThrowsError(try decodeJSON(jsonString)) { error in
+            XCTAssertEqual(error is DecodingError, true)
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    private func decodeJSON(_ jsonString: String) throws -> Object? {
+        let json = try XCTUnwrap(jsonString.data(using: .utf8))
+        let decoder = JSONDecoder()
+        return try decoder.decode(Object.self, from: json)
+    }
+}


### PR DESCRIPTION
## Motivation
Currently Toggles support only primitive types, but seemingly there is some need to add support for objects. I will be working for some time to add support for objects in Toggles. So, expect some more prs in upcomings days/weeks.

## Implementation

This is how the object based Toggle will be represented as json 👇 

<details>
<summary>Object json</summary>

```json
{
    "variable": "object_toggle",
    "object": {
        "boolProperty" : true,
        "stringProperty" : "value",
        "intProperty" : 420
    },
    "metadata": {
        "group": "Raw toggles",
        "description": "Object toggle"
    }
}
```

</details>

The basic flow for Toggles is to intake the predefined json structure and it will decode into the `Toggle` array. `Toggle` keys are predefined e.g `bool`, `int` etc. When we are talking about objects though, we need some mechanism which will allow us to use dynamic keys.

That's why I am introducing two new objects in the SDK.

### `Object`
This is the structure which will be returned to SDK consumer at the end when they ask for object value for concrete `Variable`. `Object` gives the consumers ability to access their object ether as dictionary (`map` property) or decoding that map to their expected type `T` by calling `asType<T>()`

It has custom decoding strategy. We will be decoding above mentioned json to dictionary where value is actually enum `ObjectSupportedType`. On top of that, it throws errors in several scenarios:

1. If objects key is empty.
2. If the object is empty.
3. If the object is nested.

### `ObjectSupportedType`

It makes sure that our Object has predefined value support. Each property must be either: `Bool`, `Int`, `String` or `Double`. It will throw an exception if it encounters other type while decoding.