### PR TITLE
Add object support in `ToggleObservable`

### DIFF
--- a/Sources/ObservableObjects/ToggleObservable.swift
+++ b/Sources/ObservableObjects/ToggleObservable.swift
@@ -33,6 +33,10 @@ public class ToggleObservable: ObservableObject {
     @Published
     public var secureValue: String?
     
+    /// The raw value of the toggle if it's of object type, nil otherwise.
+    @Published
+    public var objectValue: Object?
+    
     /// The default intializer.
     ///
     /// - Parameters:
@@ -64,9 +68,8 @@ public class ToggleObservable: ObservableObject {
                     self.stringValue = value
                 case .secure(let value):
                     self.secureValue = value
-                case .object:
-                    // TODO: Changes in upcoming PR
-                    break
+                case .object(let value):
+                    self.objectValue = value
                 }
             }
             .store(in: &cancellables)

--- a/Tests/Suites/ObservableObjects/ToggleObservableTests.swift
+++ b/Tests/Suites/ObservableObjects/ToggleObservableTests.swift
@@ -88,6 +88,12 @@ final class ToggleObservableTests: XCTestCase {
             }
             .store(in: &cancellables)
         
+        toggleObservable.$objectValue
+            .sink { value in
+                XCTAssertNil(value)
+            }
+            .store(in: &cancellables)
+        
         toggleManager.set(.bool(newValue), for: variable)
         
         wait(for: [rawValueExpectation, valueExpectation], timeout: 5.0)
@@ -154,6 +160,12 @@ final class ToggleObservableTests: XCTestCase {
             .store(in: &cancellables)
         
         toggleObservable.$secureValue
+            .sink { value in
+                XCTAssertNil(value)
+            }
+            .store(in: &cancellables)
+        
+        toggleObservable.$objectValue
             .sink { value in
                 XCTAssertNil(value)
             }
@@ -230,6 +242,12 @@ final class ToggleObservableTests: XCTestCase {
             }
             .store(in: &cancellables)
         
+        toggleObservable.$objectValue
+            .sink { value in
+                XCTAssertNil(value)
+            }
+            .store(in: &cancellables)
+        
         toggleManager.set(.number(newValue), for: variable)
         
         wait(for: [rawValueExpectation, valueExpectation], timeout: 5.0)
@@ -296,6 +314,12 @@ final class ToggleObservableTests: XCTestCase {
             .store(in: &cancellables)
         
         toggleObservable.$secureValue
+            .sink { value in
+                XCTAssertNil(value)
+            }
+            .store(in: &cancellables)
+        
+        toggleObservable.$objectValue
             .sink { value in
                 XCTAssertNil(value)
             }
@@ -372,7 +396,90 @@ final class ToggleObservableTests: XCTestCase {
             }
             .store(in: &cancellables)
         
-        toggleManager.set(.secure("secret"), for: variable)
+        toggleObservable.$objectValue
+            .sink { value in
+                XCTAssertNil(value)
+            }
+            .store(in: &cancellables)
+        
+        toggleManager.set(.secure(newValue), for: variable)
+        
+        wait(for: [rawValueExpectation, valueExpectation], timeout: 5.0)
+    }
+    
+    func test_objectObservable() throws {
+        let variable = "object_toggle"
+        let toggleObservable = ToggleObservable(manager: toggleManager, variable: variable)
+        
+        let valueExpectation = self.expectation(description: #function)
+        var receiveValueCount = 0
+        
+        let rawValueExpectation = self.expectation(description: #function)
+        var receiveRawValueCount = 0
+        
+        let oldValue = Object(map: [
+            "boolProperty": .bool(true),
+            "stringProperty": .string("value"),
+            "intProperty": .int(421),
+            "numberProperty": .number(12.3)]
+        )
+        let newValue = Object(map: ["var": .int(400)])
+        
+        toggleObservable.$value
+            .sink { value in
+                receiveValueCount += 1
+                switch receiveValueCount {
+                case 1:
+                    XCTAssertEqual(value, .object(oldValue))
+                case 2:
+                    XCTAssertEqual(value, .object(newValue))
+                    valueExpectation.fulfill()
+                default:
+                    XCTFail("Received more than 2 messages.")
+                }
+            }
+            .store(in: &cancellables)
+        
+        toggleObservable.$objectValue
+            .sink { value in
+                receiveRawValueCount += 1
+                switch receiveRawValueCount {
+                case 1:
+                    XCTAssertEqual(value, oldValue)
+                case 2:
+                    XCTAssertEqual(value, newValue)
+                    rawValueExpectation.fulfill()
+                default:
+                    XCTFail("Received more than 2 messages.")
+                }
+            }
+            .store(in: &cancellables)
+        
+        toggleObservable.$boolValue
+            .sink { value in
+                XCTAssertNil(value)
+            }
+            .store(in: &cancellables)
+        
+        toggleObservable.$intValue
+            .sink { value in
+                XCTAssertNil(value)
+            }
+            .store(in: &cancellables)
+        
+        toggleObservable.$numberValue
+            .sink { value in
+                XCTAssertNil(value)
+            }
+            .store(in: &cancellables)
+        
+        toggleObservable.$stringValue
+            .sink { value in
+                XCTAssertNil(value)
+            }
+            .store(in: &cancellables)
+        
+        toggleManager.set(.object(newValue), for: variable)
         
         wait(for: [rawValueExpectation, valueExpectation], timeout: 5.0)
     }


### PR DESCRIPTION
## Motivation
Currently Toggles support only primitive types, but seemingly there is some need to add support for objects. I will be working for some time to add support for objects in Toggles. So, expect some more prs in upcomings days/weeks.

I have added `Object` support in https://github.com/TogglesPlatform/Toggles/pull/37, but did not include the `ToggleObservable` changes in order to reduce diff. 

## Implementation

I have added new `public var objectValue: Object?` in `ToggleObservable` and added the tests to make sure it works as expected.