### PR TITLE
Add object support in ToggleGen

### DIFF
--- a/Sources/Models/Object.swift
+++ b/Sources/Models/Object.swift
@@ -20,7 +20,7 @@ public struct Object {
     
     /// Object description represented as plain json string. 
     /// Returns nil if object cant be represented as json string.
-    var description: String? {
+    public var description: String? {
         let encoder = JSONEncoder()
         guard let value = try? encoder.encode(map) else {
             return nil

--- a/ToggleGen/Demo/DemoDatasource.json
+++ b/ToggleGen/Demo/DemoDatasource.json
@@ -39,6 +39,16 @@
       "variable": "string_toggle_2",
       "string": "Ciao Mondo",
       "propertyName": "userDefinedStringToggle"
+    },
+    {
+      "variable": "object_toggle",
+      "object": {
+        "boolProperty" : true,
+        "stringProperty" : "value",
+        "intProperty" : 420,
+        "numberProperty": 13.6
+      },
+      "propertyName": "userDefinedObjectToggle"
     }
   ]
 }

--- a/ToggleGen/GeneratedCode/ToggleAccessor.swift
+++ b/ToggleGen/GeneratedCode/ToggleAccessor.swift
@@ -1,11 +1,13 @@
 //  ToggleAccessor.swift
 
+// swiftlint:disable file_length
+
 import Foundation
 import Toggles
 
 public class ToggleAccessor {
     
-    private let manager: ToggleManager
+    private(set) var manager: ToggleManager
     
     public init(manager: ToggleManager) {
         self.manager = manager
@@ -39,24 +41,31 @@ extension ToggleAccessor {
         set { manager.set(.secure(newValue), for: ToggleVariables.encryptedToggle) }
     }
 
-    public var userDefinedBooleanToggle: Bool {
+    public var booleanToggle2: Bool {
         get { manager.value(for: ToggleVariables.booleanToggle2).boolValue! }
         set { manager.set(.bool(newValue), for: ToggleVariables.booleanToggle2) }
     }
 
-    public var userDefinedIntegerToggle: Int {
+    public var integerToggle2: Int {
         get { manager.value(for: ToggleVariables.integerToggle2).intValue! }
         set { manager.set(.int(newValue), for: ToggleVariables.integerToggle2) }
     }
 
-    public var userDefinedNumericToggle: Double {
+    public var numericToggle2: Double {
         get { manager.value(for: ToggleVariables.numericToggle2).numberValue! }
         set { manager.set(.number(newValue), for: ToggleVariables.numericToggle2) }
     }
 
-    public var userDefinedStringToggle: String {
+    public var stringToggle2: String {
         get { manager.value(for: ToggleVariables.stringToggle2).stringValue! }
         set { manager.set(.string(newValue), for: ToggleVariables.stringToggle2) }
     }
 
+    public var objectToggle: Object {
+        get { manager.value(for: ToggleVariables.objectToggle).objectValue! }
+        set { manager.set(.object(newValue), for: ToggleVariables.objectToggle) }
+    }
+
 }
+
+// swiftlint:enable file_length

--- a/ToggleGen/GeneratedCode/ToggleVariables.swift
+++ b/ToggleGen/GeneratedCode/ToggleVariables.swift
@@ -1,8 +1,10 @@
 //  ToggleVariables.swift
 
+// swiftlint:disable file_length
+
 import Foundation
 
-public struct ToggleVariables {
+public enum ToggleVariables {
 
     public static let booleanToggle = "boolean_toggle"
 
@@ -22,4 +24,8 @@ public struct ToggleVariables {
 
     public static let stringToggle2 = "string_toggle_2"
 
+    public static let objectToggle = "object_toggle"
+
 }
+
+// swiftlint:enable file_length

--- a/ToggleGen/Sources/Extensions/Models+Decodable.swift
+++ b/ToggleGen/Sources/Extensions/Models+Decodable.swift
@@ -15,6 +15,7 @@ extension Toggle: Decodable {
         case number
         case string
         case secure
+        case object
         case metadata
     }
     
@@ -35,6 +36,9 @@ extension Toggle: Decodable {
         }
         else if let secureValue = try? values.decode(String.self, forKey: .secure) {
             self.value = .secure(secureValue)
+        }
+        else if let objectValue = try? values.decode(Object.self, forKey: .object) {
+            self.value = .object(objectValue)
         }
         else {
             throw CodingError.missingValue

--- a/ToggleGen/Sources/Extensions/Models+Utilities.swift
+++ b/ToggleGen/Sources/Extensions/Models+Utilities.swift
@@ -30,6 +30,8 @@ extension Toggle {
             return "String"
         case .secure:
             return "String"
+        case .object:
+            return "Object"
         }
     }
     
@@ -45,6 +47,8 @@ extension Toggle {
             return "string"
         case .secure:
             return "secure"
+        case .object:
+            return "object"
         }
     }
 }

--- a/ToggleGen/Sources/Models/Models.swift
+++ b/ToggleGen/Sources/Models/Models.swift
@@ -16,6 +16,7 @@ struct Toggle: Equatable {
         case number(Double)
         case string(String)
         case secure(String)
+        case object(Object)
     }
     
     let variable: Variable

--- a/ToggleGen/Sources/Models/Object.swift
+++ b/ToggleGen/Sources/Models/Object.swift
@@ -1,0 +1,28 @@
+//  Object.swift
+
+import Foundation
+
+struct Object: Equatable, Decodable {
+    let map: [String: ObjectSupportedType]
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if let dictionary = try? container.decode([String: ObjectSupportedType].self) {
+            var map = [String: ObjectSupportedType]()
+            for (key, item) in dictionary {
+                guard !key.isEmpty else {
+                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "JSON contained empty key. Invalid data.")
+                }
+                map[key] = item
+            }
+            if map.isEmpty {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Empty object. Invalid data.")
+            }
+            
+            self.map = map
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported type. Invalid data.")
+        }
+    }
+}

--- a/ToggleGen/Sources/Models/ObjectSupportedType.swift
+++ b/ToggleGen/Sources/Models/ObjectSupportedType.swift
@@ -1,0 +1,27 @@
+//  ObjectSupportedType.swift
+
+import Foundation
+
+enum ObjectSupportedType: Equatable, Decodable {
+    case bool(Bool)
+    case int(Int)
+    case number(Double)
+    case string(String)
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self = .int(int)
+        } else if let number = try? container.decode(Double.self) {
+            self = .number(number)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "ObjectSupportedType tried to decode unsupported type, could not decode")
+        }
+    }
+}
+

--- a/ToggleGen/Sources/ToggleGen.swift
+++ b/ToggleGen/Sources/ToggleGen.swift
@@ -18,7 +18,7 @@ struct ToggleGen: ParsableCommand {
     @Option(name: .long, help: "The name of the accessor class to generate.")
     var accessorClassName: String
     
-    @Option(name: .long, help: "The path of the datas ource to use.")
+    @Option(name: .long, help: "The path of the datas source to use.")
     var datasourcePath: String
     
     @Option(name: .long, help: "The path to the folder to write the ToggleAccessor file to.")

--- a/TogglesDemo/TogglesDemo/GeneratedCode/ToggleAccessor.swift
+++ b/TogglesDemo/TogglesDemo/GeneratedCode/ToggleAccessor.swift
@@ -1,11 +1,13 @@
 //  ToggleAccessor.swift
 
+// swiftlint:disable file_length
+
 import Foundation
 import Toggles
 
 public class ToggleAccessor {
     
-    private let manager: ToggleManager
+    private(set) var manager: ToggleManager
     
     public init(manager: ToggleManager) {
         self.manager = manager
@@ -13,6 +15,11 @@ public class ToggleAccessor {
 }
 
 extension ToggleAccessor {
+
+    public var objectToggle: Object {
+        get { manager.value(for: ToggleVariables.objectToggle).objectValue! }
+        set { manager.set(.object(newValue), for: ToggleVariables.objectToggle) }
+    }
 
     public var booleanToggle: Bool {
         get { manager.value(for: ToggleVariables.booleanToggle).boolValue! }
@@ -50065,3 +50072,5 @@ extension ToggleAccessor {
     }
 
 }
+
+// swiftlint:enable file_length

--- a/TogglesDemo/TogglesDemo/GeneratedCode/ToggleVariables.swift
+++ b/TogglesDemo/TogglesDemo/GeneratedCode/ToggleVariables.swift
@@ -1,8 +1,12 @@
 //  ToggleVariables.swift
 
+// swiftlint:disable file_length
+
 import Foundation
 
-public struct ToggleVariables {
+public enum ToggleVariables {
+
+    public static let objectToggle = "object_toggle"
 
     public static let booleanToggle = "boolean_toggle"
 
@@ -20025,3 +20029,5 @@ public struct ToggleVariables {
     public static let string9999 = "String_9999"
 
 }
+
+// swiftlint:enable file_length

--- a/TogglesDemo/TogglesDemo/Resources/10kEntriesDemoDatasource.json
+++ b/TogglesDemo/TogglesDemo/Resources/10kEntriesDemoDatasource.json
@@ -1,5 +1,17 @@
 {"toggles":[
     {
+        "variable": "object_toggle",
+        "object": {
+            "boolProperty" : true,
+            "stringProperty" : "value",
+            "intProperty" : 420
+        },
+        "metadata": {
+            "group": "Raw toggles",
+            "description": "Object toggle"
+        }
+    },
+    {
         "variable": "boolean_toggle",
         "bool": true,
         "metadata": {

--- a/TogglesDemo/TogglesDemo/Resources/DemoDatasource.json
+++ b/TogglesDemo/TogglesDemo/Resources/DemoDatasource.json
@@ -9,16 +9,16 @@
       }
     },
     {
-        "variable": "object_toggle",
-        "object": {
-            "boolProperty" : true,
-            "stringProperty" : "value",
-            "intProperty" : 420
-        },
-        "metadata": {
-            "group": "Raw toggles",
-            "description": "Object toggle"
-        }
+      "variable": "object_toggle",
+      "object": {
+        "boolProperty" : true,
+        "stringProperty" : "value",
+        "intProperty" : 420
+      },
+      "metadata": {
+        "group": "Raw toggles",
+        "description": "Object toggle"
+      }
     },
     {
       "variable": "integer_toggle",

--- a/TogglesDemo/TogglesDemo/Sources/Views/ToggleObservablesView.swift
+++ b/TogglesDemo/TogglesDemo/Sources/Views/ToggleObservablesView.swift
@@ -15,6 +15,7 @@ The view will show the values updating when overrides or new configurations are 
     @ObservedObject var numericObservable: ToggleObservable
     @ObservedObject var stringObservable: ToggleObservable
     @ObservedObject var secureObservable: ToggleObservable
+    @ObservedObject var objectObservable: ToggleObservable
 
     init(manager: ToggleManager) {
         self.booleanObservable = ToggleObservable(manager: manager, variable: ToggleVariables.booleanToggle)
@@ -22,6 +23,7 @@ The view will show the values updating when overrides or new configurations are 
         self.numericObservable = ToggleObservable(manager: manager, variable: ToggleVariables.numericToggle)
         self.stringObservable = ToggleObservable(manager: manager, variable: ToggleVariables.stringToggle)
         self.secureObservable = ToggleObservable(manager: manager, variable: ToggleVariables.encryptedToggle)
+        self.objectObservable = ToggleObservable(manager: manager, variable: ToggleVariables.objectToggle)
     }
         
     var body: some View {
@@ -52,6 +54,9 @@ The view will show the values updating when overrides or new configurations are 
                     HStack {
                         Text(ToggleVariables.encryptedToggle)
                     }
+                    HStack {
+                        Text(ToggleVariables.objectToggle)
+                    }
                 }
                 VStack(alignment: .leading) {
                     HStack {
@@ -68,6 +73,9 @@ The view will show the values updating when overrides or new configurations are 
                     }
                     HStack {
                         Text(secureObservable.secureValue!)
+                    }
+                    HStack {
+                        Text(objectObservable.objectValue?.description ?? "unknown")
                     }
                 }
             }

--- a/TogglesDemo/TogglesDemo/Sources/Views/ToggleObservablesView.swift
+++ b/TogglesDemo/TogglesDemo/Sources/Views/ToggleObservablesView.swift
@@ -37,48 +37,32 @@ The view will show the values updating when overrides or new configurations are 
                 .padding()
             Text(message)
                 .padding()
-            HStack {
-                VStack(alignment: .trailing) {
-                    HStack {
-                        Text(ToggleVariables.booleanToggle)
-                    }
-                    HStack {
-                        Text(ToggleVariables.integerToggle)
-                    }
-                    HStack {
-                        Text(ToggleVariables.numericToggle)
-                    }
-                    HStack {
-                        Text(ToggleVariables.stringToggle)
-                    }
-                    HStack {
-                        Text(ToggleVariables.encryptedToggle)
-                    }
-                    HStack {
-                        Text(ToggleVariables.objectToggle)
-                    }
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("\(ToggleVariables.booleanToggle):")
+                    Text(String(booleanObservable.boolValue!))
                 }
-                VStack(alignment: .leading) {
-                    HStack {
-                        Text(String(booleanObservable.boolValue!))
-                    }
-                    HStack {
-                        Text(String(intObservable.intValue!))
-                    }
-                    HStack {
-                        Text(String(numericObservable.numberValue!))
-                    }
-                    HStack {
-                        Text(stringObservable.stringValue!)
-                    }
-                    HStack {
-                        Text(secureObservable.secureValue!)
-                    }
-                    HStack {
-                        Text(objectObservable.objectValue?.description ?? "unknown")
-                    }
+                HStack {
+                    Text("\(ToggleVariables.integerToggle):")
+                    Text(String(intObservable.intValue!))
                 }
-            }
+                HStack {
+                    Text("\(ToggleVariables.numericToggle):")
+                    Text(String(numericObservable.numberValue!))
+                }
+                HStack {
+                    Text("\(ToggleVariables.stringToggle):")
+                    Text(stringObservable.stringValue!)
+                }
+                HStack {
+                    Text("\(ToggleVariables.encryptedToggle):")
+                    Text(secureObservable.secureValue!)
+                }
+                HStack {
+                    Text("\(ToggleVariables.objectToggle):")
+                    Text(objectObservable.objectValue?.description ?? "unknown")
+                }
+            }.padding(.horizontal, 24)
         }
     }
 }


### PR DESCRIPTION
I have finalised `object` support in Toggles. Now it's time to add `object` support in `ToggleGen`.

* Added `Object` and `ObjectSupportedType` in `ToggleGen` package.
* Executed `ToggleGen` script to generate new object properties. 
* Updated demo app to demonstrate object observable functionality.

<video width='200' src='https://github.com/TogglesPlatform/Toggles/assets/9494262/5b76f585-72ab-40ff-baee-546f884764c8'>
