### PR TITLE
Swift 6 support

### DIFF
--- a/.github/workflows/build-TogglesDemo.yml
+++ b/.github/workflows/build-TogglesDemo.yml
@@ -9,12 +9,12 @@ on:
       - main
 
 env:
-  XCODE_VERSION: 14.0.1
+  XCODE_VERSION: 15.2.0
 
 jobs:
   test:
     name: Build
-    runs-on: macos-12
+    runs-on: macos-14.2.1
     steps:
     - name: Show macOS version
       run: sw_vers
@@ -36,4 +36,4 @@ jobs:
       run: xcodebuild -showdestinations -scheme TogglesDemo
     - name: Build for destination TogglesDemo
       working-directory: ./TogglesDemo
-      run: xcodebuild build -scheme TogglesDemo -destination "platform=iOS Simulator,OS=16.0,name=iPhone 14 Pro"
+      run: xcodebuild build -scheme TogglesDemo -destination "platform=iOS Simulator,OS=17.2,name=iPhone 15 Pro"

--- a/.github/workflows/build-TogglesDemo.yml
+++ b/.github/workflows/build-TogglesDemo.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: Build
-    runs-on: macos-14.2.1
+    runs-on: macos-14
     steps:
     - name: Show macOS version
       run: sw_vers

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,12 +6,12 @@ on:
       - '*'
 
 env:
-  XCODE_VERSION: 14.0.1
+  XCODE_VERSION: 15.2.0
 
 jobs:
   publish-release:
     name: Publish release ${{ github.ref_name }}
-    runs-on: macos-12
+    runs-on: macos-14.2.1
     steps:
     - name: Show macOS version (${{ env.XCODE_VERSION }})
       run: sw_vers

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   publish-release:
     name: Publish release ${{ github.ref_name }}
-    runs-on: macos-14.2.1
+    runs-on: macos-14
     steps:
     - name: Show macOS version (${{ env.XCODE_VERSION }})
       run: sw_vers

--- a/.github/workflows/run-tests-JustTweakMigrator.yml
+++ b/.github/workflows/run-tests-JustTweakMigrator.yml
@@ -9,12 +9,12 @@ on:
       - main
 
 env:
-  XCODE_VERSION: 14.0.1
+  XCODE_VERSION: 15.2.0
 
 jobs:
   test:
     name: Run tests
-    runs-on: macos-12
+    runs-on: macos-14.2.1
     steps:
     - name: Code Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/run-tests-JustTweakMigrator.yml
+++ b/.github/workflows/run-tests-JustTweakMigrator.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: Run tests
-    runs-on: macos-14.2.1
+    runs-on: macos-14
     steps:
     - name: Code Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/run-tests-ToggleCipher.yml
+++ b/.github/workflows/run-tests-ToggleCipher.yml
@@ -9,12 +9,12 @@ on:
       - main
 
 env:
-  XCODE_VERSION: 14.0.1
+  XCODE_VERSION: 15.2.0
 
 jobs:
   test:
     name: Run tests
-    runs-on: macos-12
+    runs-on: macos-14.2.1
     steps:
     - name: Code Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/run-tests-ToggleCipher.yml
+++ b/.github/workflows/run-tests-ToggleCipher.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: Run tests
-    runs-on: macos-14.2.1
+    runs-on: macos-14
     steps:
     - name: Code Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/run-tests-ToggleGen.yml
+++ b/.github/workflows/run-tests-ToggleGen.yml
@@ -9,12 +9,12 @@ on:
       - main
 
 env:
-  XCODE_VERSION: 14.0.1
+  XCODE_VERSION: 15.2.0
 
 jobs:
   test:
     name: Run tests
-    runs-on: macos-12
+    runs-on: macos-14.2.1
     steps:
     - name: Code Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/run-tests-ToggleGen.yml
+++ b/.github/workflows/run-tests-ToggleGen.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: Run tests
-    runs-on: macos-14.2.1
+    runs-on: macos-14
     steps:
     - name: Code Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/run-tests-Toggles.yml
+++ b/.github/workflows/run-tests-Toggles.yml
@@ -9,12 +9,12 @@ on:
       - main
 
 env:
-  XCODE_VERSION: 14.0.1
+  XCODE_VERSION: 15.2.0
 
 jobs:
   test:
     name: Run tests
-    runs-on: macos-12
+    runs-on: macos-14.2.1
     steps:
     - name: Code Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/run-tests-Toggles.yml
+++ b/.github/workflows/run-tests-Toggles.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     name: Run tests
-    runs-on: macos-14.2.1
+    runs-on: macos-14
     steps:
     - name: Code Checkout
       uses: actions/checkout@v2

--- a/JustTweakMigrator/Package.swift
+++ b/JustTweakMigrator/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -24,13 +24,37 @@ let package = Package(
             name: "Toggles",
             dependencies: [],
             path: "Sources",
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: [
+                .enableExperimentalFeature("ConciseMagicFile"),
+                .enableExperimentalFeature("ForwardTrailingClosures"),
+                .enableExperimentalFeature("BareSlashRegexLiterals"),
+                .enableExperimentalFeature("DeprecateApplicationMain"),
+                .enableExperimentalFeature("ImportObjcForwardDeclarations"),
+                .enableExperimentalFeature("DisableOutwardActorInference"),
+                .enableExperimentalFeature("InternalImportsByDefault"),
+                .enableExperimentalFeature("ExistentialAny"),
+                .enableExperimentalFeature("ImplicitOpenExistentials"),
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
         ),
         .testTarget(
             name: "TogglesTests",
             dependencies: ["Toggles"],
             path: "Tests",
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: [
+                .enableExperimentalFeature("ConciseMagicFile"),
+                .enableExperimentalFeature("ForwardTrailingClosures"),
+                .enableExperimentalFeature("BareSlashRegexLiterals"),
+                .enableExperimentalFeature("DeprecateApplicationMain"),
+                .enableExperimentalFeature("ImportObjcForwardDeclarations"),
+                .enableExperimentalFeature("DisableOutwardActorInference"),
+                .enableExperimentalFeature("InternalImportsByDefault"),
+                .enableExperimentalFeature("ExistentialAny"),
+                .enableExperimentalFeature("ImplicitOpenExistentials"),
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,37 +24,13 @@ let package = Package(
             name: "Toggles",
             dependencies: [],
             path: "Sources",
-            resources: [.process("Resources")],
-            swiftSettings: [
-                .enableExperimentalFeature("ConciseMagicFile"),
-                .enableExperimentalFeature("ForwardTrailingClosures"),
-                .enableExperimentalFeature("BareSlashRegexLiterals"),
-                .enableExperimentalFeature("DeprecateApplicationMain"),
-                .enableExperimentalFeature("ImportObjcForwardDeclarations"),
-                .enableExperimentalFeature("DisableOutwardActorInference"),
-                .enableExperimentalFeature("InternalImportsByDefault"),
-                .enableExperimentalFeature("ExistentialAny"),
-                .enableExperimentalFeature("ImplicitOpenExistentials"),
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            resources: [.process("Resources")]
         ),
         .testTarget(
             name: "TogglesTests",
             dependencies: ["Toggles"],
             path: "Tests",
-            resources: [.process("Resources")],
-            swiftSettings: [
-                .enableExperimentalFeature("ConciseMagicFile"),
-                .enableExperimentalFeature("ForwardTrailingClosures"),
-                .enableExperimentalFeature("BareSlashRegexLiterals"),
-                .enableExperimentalFeature("DeprecateApplicationMain"),
-                .enableExperimentalFeature("ImportObjcForwardDeclarations"),
-                .enableExperimentalFeature("DisableOutwardActorInference"),
-                .enableExperimentalFeature("InternalImportsByDefault"),
-                .enableExperimentalFeature("ExistentialAny"),
-                .enableExperimentalFeature("ImplicitOpenExistentials"),
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            resources: [.process("Resources")]
         )
     ]
 )

--- a/Sources/Models/Object.swift
+++ b/Sources/Models/Object.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Model representing object value for a Toggle.
 /// It container to access a object as a dictionary or a concrete type `T`
-public struct Object {
+public struct Object: Sendable {
     public let map: [Variable: ObjectSupportedType]
     
     public init(map: [Variable: ObjectSupportedType]) {

--- a/Sources/Models/ObjectSupportedType.swift
+++ b/Sources/Models/ObjectSupportedType.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /// Supported types for `Object`
-public enum ObjectSupportedType {
+public enum ObjectSupportedType: Sendable {
     case bool(Bool)
     case int(Int)
     case number(Double)

--- a/Sources/Models/Value.swift
+++ b/Sources/Models/Value.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /// Value associated with a toggle.
-public enum Value: Equatable, Codable {
+public enum Value: Equatable, Codable, Sendable {
     case bool(Bool)
     case int(Int)
     case number(Double)

--- a/Sources/Protocols/MutableValueProvider.swift
+++ b/Sources/Protocols/MutableValueProvider.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Protocol to be implemented by custom mutable value providers.
 /// A MutableValueProvider is a ValueProvider that allows settings and deleting values for given variables.
-public protocol MutableValueProvider: ValueProvider {
+public protocol MutableValueProvider: ValueProvider & Sendable {
     
     /// Sets the value for a variable.
     ///

--- a/Sources/Protocols/ValueProvider.swift
+++ b/Sources/Protocols/ValueProvider.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Protocol to be implemented by custom value providers.
 /// A ValueProvider allows retrieving values for given variables.
-public protocol ValueProvider {
+public protocol ValueProvider: Sendable {
     var name: String { get }
     
     /// Retrieve the value for a variable.

--- a/Sources/Providers/InMemoryValueProvider.swift
+++ b/Sources/Providers/InMemoryValueProvider.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Mutable value provider that stores toggles in memory.
 /// Alterations to toggles are not persisted.
-final public class InMemoryValueProvider {
+final public class InMemoryValueProvider: @unchecked Sendable {
     
     public let name: String
     

--- a/Sources/Providers/PersistentValueProvider.swift
+++ b/Sources/Providers/PersistentValueProvider.swift
@@ -6,7 +6,7 @@ private let userDefaultsKeyPrefix = "com.toggles"
 
 /// Mutable value provider that persists toggles in the user defaults.
 /// Alterations to toggles are therefore persisted across app restarts and updates.
-final public class PersistentValueProvider {
+final public class PersistentValueProvider: @unchecked Sendable {
     
     public let name: String
     

--- a/Sources/ToggleManager/ToggleManager.swift
+++ b/Sources/ToggleManager/ToggleManager.swift
@@ -4,7 +4,7 @@ import Combine
 import Foundation
 
 /// Thread-safe facade to interface with toggles.
-final public class ToggleManager: ObservableObject {
+final public class ToggleManager: ObservableObject, @unchecked Sendable {
     
     public struct ToggleManagerOptions: OptionSet {
         public var rawValue: UInt

--- a/Tests/Utilities/MockRemoteValueProvider.swift
+++ b/Tests/Utilities/MockRemoteValueProvider.swift
@@ -3,9 +3,9 @@
 import Foundation
 @testable import Toggles
 
-final class MockRemoteValueProvider: ValueProvider {
+final class MockRemoteValueProvider: ValueProvider, @unchecked Sendable {
     
-    var name: String = "Remote (mock)"
+    let name: String = "Remote (mock)"
     
     private var toggles: [Variable: Value]
     

--- a/Tests/Utilities/SingleValueMockProvider.swift
+++ b/Tests/Utilities/SingleValueMockProvider.swift
@@ -3,9 +3,9 @@
 import Foundation
 import Toggles
 
-class MockSingleValueProvider: ValueProvider {
+final class MockSingleValueProvider: ValueProvider {
     
-    var name: String = "SingleValue (mock)"
+    let name: String = "SingleValue (mock)"
     
     private let value: Value
     

--- a/ToggleCipher/Package.swift
+++ b/ToggleCipher/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -20,10 +20,34 @@ let package = Package(
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
-            path: "Sources"),
+            path: "Sources",
+            swiftSettings: [
+                            .enableExperimentalFeature("ConciseMagicFile"),
+                            .enableExperimentalFeature("ForwardTrailingClosures"),
+                            .enableExperimentalFeature("BareSlashRegexLiterals"),
+                            .enableExperimentalFeature("DeprecateApplicationMain"),
+                            .enableExperimentalFeature("ImportObjcForwardDeclarations"),
+                            .enableExperimentalFeature("DisableOutwardActorInference"),
+                            .enableExperimentalFeature("InternalImportsByDefault"),
+                            .enableExperimentalFeature("ExistentialAny"),
+                            .enableExperimentalFeature("ImplicitOpenExistentials"),
+                            .enableExperimentalFeature("StrictConcurrency")
+                        ]),
         .testTarget(
             name: "ToggleCipherTests",
             dependencies: ["ToggleCipher"],
-            path: "Tests")
+            path: "Tests",
+            swiftSettings: [
+                            .enableExperimentalFeature("ConciseMagicFile"),
+                            .enableExperimentalFeature("ForwardTrailingClosures"),
+                            .enableExperimentalFeature("BareSlashRegexLiterals"),
+                            .enableExperimentalFeature("DeprecateApplicationMain"),
+                            .enableExperimentalFeature("ImportObjcForwardDeclarations"),
+                            .enableExperimentalFeature("DisableOutwardActorInference"),
+                            .enableExperimentalFeature("InternalImportsByDefault"),
+                            .enableExperimentalFeature("ExistentialAny"),
+                            .enableExperimentalFeature("ImplicitOpenExistentials"),
+                            .enableExperimentalFeature("StrictConcurrency")
+                        ])
     ]
 )

--- a/ToggleGen/Package.swift
+++ b/ToggleGen/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/TogglesDemo/TogglesDemo.xcodeproj/project.pbxproj
+++ b/TogglesDemo/TogglesDemo.xcodeproj/project.pbxproj
@@ -302,7 +302,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				"OTHER_SWIFT_FLAGS[arch=*]" = "-Xfrontend -enable-actor-data-race-checks";
+				"OTHER_SWIFT_FLAGS[arch=*]" = "-Xfrontend -enable-actor-data-race-checks -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature DeprecateApplicationMain -enable-upcoming-feature ImportObjcForwardDeclarations -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature InternalImportsByDefault -enable-upcoming-feature ExistentialAny -enable-upcoming-feature ImplicitOpenExistentials -warn-concurrency";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";

--- a/TogglesDemo/TogglesDemo.xcodeproj/project.pbxproj
+++ b/TogglesDemo/TogglesDemo.xcodeproj/project.pbxproj
@@ -302,7 +302,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				"OTHER_SWIFT_FLAGS[arch=*]" = "-Xfrontend -enable-actor-data-race-checks -enable-upcoming-feature ConciseMagicFile -enable-upcoming-feature ForwardTrailingClosures -enable-upcoming-feature BareSlashRegexLiterals -enable-upcoming-feature DeprecateApplicationMain -enable-upcoming-feature ImportObjcForwardDeclarations -enable-upcoming-feature DisableOutwardActorInference -enable-upcoming-feature InternalImportsByDefault -enable-upcoming-feature ExistentialAny -enable-upcoming-feature ImplicitOpenExistentials -warn-concurrency";
+				"OTHER_SWIFT_FLAGS[arch=*]" = "-Xfrontend -enable-actor-data-race-checks -warn-concurrency";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";

--- a/TogglesDemo/TogglesDemo/Sources/DemoConfiguration.swift
+++ b/TogglesDemo/TogglesDemo/Sources/DemoConfiguration.swift
@@ -19,7 +19,7 @@ class DemoConfiguration {
     
     let datasourceUrl: URL
     let remoteValueProvider: RemoteValueProvider
-    let localValueProvider: ValueProvider
+    let localValueProvider: LocalValueProvider
     let cipherConfiguration: CipherConfiguration
     let manager: ToggleManager
     

--- a/TogglesDemo/TogglesDemo/Sources/Providers/RemoteValueProvider.swift
+++ b/TogglesDemo/TogglesDemo/Sources/Providers/RemoteValueProvider.swift
@@ -3,7 +3,7 @@
 import Foundation
 import Toggles
 
-public class RemoteValueProvider: ValueProvider {
+public class RemoteValueProvider: ValueProvider, @unchecked Sendable {
     
     public var name: String = "Remote (demo)"
     

--- a/TogglesDemo/TogglesDemo/Sources/Views/ToggleObservablesView.swift
+++ b/TogglesDemo/TogglesDemo/Sources/Views/ToggleObservablesView.swift
@@ -3,6 +3,7 @@
 import SwiftUI
 import Toggles
 
+@MainActor
 struct ToggleObservablesView: View {
     
     let message = """


### PR DESCRIPTION
This PR updates the Toggles package to compile with Swift 6 features enabled. 

Toggles was already thread safe, so the `TogglesFacade` could safely be marked as `@unchecked`.

**Note** that `Object` values now require `Sendable` conformance.