### PR TITLE
Remove cache evicting when removing overrides

### DIFF
--- a/Sources/ToggleManager/ToggleManager+Overrides.swift
+++ b/Sources/ToggleManager/ToggleManager+Overrides.swift
@@ -13,11 +13,9 @@ extension ToggleManager {
     }
     
     /// Removes all overridden toggles in the mutable value provider, if one was provided during initialization.
-    /// This method also clears the cache.
     @discardableResult
     public func removeOverrides() -> Set<Variable> {
         queue.sync(flags: .barrier) {
-            defer { cache.evict() }
             guard let mutableValueProvider = mutableValueProvider else { return  [] }
             let variables = mutableValueProvider.variables
             for variable in variables {

--- a/Tests/Suites/ToggleManager/ToggleManager+OverridesTests.swift
+++ b/Tests/Suites/ToggleManager/ToggleManager+OverridesTests.swift
@@ -34,4 +34,12 @@ final class ToggleManager_OverridesTests: XCTestCase {
         toggleManager.removeOverrides()
         XCTAssertEqual(toggleManager.overrides, [])
     }
+    
+    func test_removeOverrides_doesNotDeleteCache() throws {
+        let toggleManager = try ToggleManager(mutableValueProvider: InMemoryValueProvider(),
+                                              datasourceUrl: url)
+        _ = toggleManager.value(for: "string_toggle")
+        toggleManager.removeOverrides()
+        XCTAssertNotNil(toggleManager.cache.value(forKey: "string_toggle"))
+    }
 }


### PR DESCRIPTION
I am addressing simple issue -> https://github.com/TogglesPlatform/Toggles/issues/17

When removing the overrides the function was [evicting](https://github.com/TogglesPlatform/Toggles/blob/ba9d0a93f3f7b1da6d184d5532961d9d3b79c158/Sources/ToggleManager/ToggleManager%2BOverrides.swift#L20) entire cache, which we all agree is not ideal. The purpose of this pr is to fix it.

It is quite simple and self-explanatory fix with a simple test.