### PR TITLE
Add support for the default ACL

### DIFF
--- a/ToggleGen/Sources/Core/Generator.swift
+++ b/ToggleGen/Sources/Core/Generator.swift
@@ -46,13 +46,13 @@ class Generator {
     
     func generateVariables(variablesTemplatePath: String,
                            variablesEnumName: String,
-                           accessControl: AccessControl) throws -> String {
+                           accessControl: AccessControl?) throws -> String {
         let templater = Templater()
         let variablesTemplateUrl = URL(fileURLWithPath: variablesTemplatePath)
-        let variablesContext: [String: Any] = [
+        let variablesContext: [String: Any?] = [
             Constants.enumName.rawValue: variablesEnumName,
             Constants.variables.rawValue: loadVariables(),
-            Constants.accessControl.rawValue: accessControl.rawValue
+            Constants.accessControl.rawValue: accessControl?.rawValue
         ]
         return try templater.renderTemplate(at: variablesTemplateUrl, with: variablesContext)
     }
@@ -60,14 +60,14 @@ class Generator {
     func generateAccessor(accessorTemplatePath: String,
                           variablesEnumName: String,
                           accessorClassName: String,
-                          accessControl: AccessControl) throws -> String {
+                          accessControl: AccessControl?) throws -> String {
         let templater = Templater()
         let accessorTemplateUrl = URL(fileURLWithPath: accessorTemplatePath)
-        let accessorContext: [String: Any] = [
+        let accessorContext: [String: Any?] = [
             Constants.className.rawValue: accessorClassName,
             Constants.enumName.rawValue: variablesEnumName,
             Constants.accessorInfos.rawValue: loadAccessorInfos(),
-            Constants.accessControl.rawValue: accessControl.rawValue
+            Constants.accessControl.rawValue: accessControl?.rawValue
         ]
         return try templater.renderTemplate(at: accessorTemplateUrl, with: accessorContext)
     }

--- a/ToggleGen/Sources/Core/Generator.swift
+++ b/ToggleGen/Sources/Core/Generator.swift
@@ -49,11 +49,14 @@ class Generator {
                            accessControl: AccessControl?) throws -> String {
         let templater = Templater()
         let variablesTemplateUrl = URL(fileURLWithPath: variablesTemplatePath)
-        let variablesContext: [String: Any?] = [
+        var variablesContext: [String: Any] = [
             Constants.enumName.rawValue: variablesEnumName,
-            Constants.variables.rawValue: loadVariables(),
-            Constants.accessControl.rawValue: accessControl?.rawValue
+            Constants.variables.rawValue: loadVariables()
         ]
+        if let accessControlValue = accessControl?.rawValue {
+            variablesContext[Constants.accessControl.rawValue] = accessControlValue
+        }
+
         return try templater.renderTemplate(at: variablesTemplateUrl, with: variablesContext)
     }
     
@@ -63,12 +66,15 @@ class Generator {
                           accessControl: AccessControl?) throws -> String {
         let templater = Templater()
         let accessorTemplateUrl = URL(fileURLWithPath: accessorTemplatePath)
-        let accessorContext: [String: Any?] = [
+        var accessorContext: [String: Any] = [
             Constants.className.rawValue: accessorClassName,
             Constants.enumName.rawValue: variablesEnumName,
-            Constants.accessorInfos.rawValue: loadAccessorInfos(),
-            Constants.accessControl.rawValue: accessControl?.rawValue
+            Constants.accessorInfos.rawValue: loadAccessorInfos()
         ]
+        if let accessControlValue = accessControl?.rawValue {
+            accessorContext[Constants.accessControl.rawValue] = accessControlValue
+        }
+
         return try templater.renderTemplate(at: accessorTemplateUrl, with: accessorContext)
     }
     

--- a/ToggleGen/Tests/GeneratorTests.swift
+++ b/ToggleGen/Tests/GeneratorTests.swift
@@ -42,6 +42,18 @@ final class GeneratorTests: XCTestCase {
         XCTAssertEqual(generatedContent, expectedContent)
     }
 
+    func test_givenAccessControlNil_whenGenerateVariables_thenAccessControlIsDefault() throws {
+        let datasourceUrl = Bundle.module.url(forResource: "TestDatasource", withExtension: "json")!
+        let generator = try Generator(datasourceUrl: datasourceUrl)
+        let variablesTemplateUrl = Bundle.module.path(forResource: "Variables", ofType: "stencil")!
+        let generatedContent = try generator.generateVariables(variablesTemplatePath: variablesTemplateUrl,
+                                                               variablesEnumName: "TestVariables",
+                                                               accessControl: nil)
+        let variablesUrl = Bundle.module.url(forResource: "TestVariables_nil", withExtension: "txt")!
+        let expectedContent = try String(contentsOf: variablesUrl)
+        XCTAssertEqual(generatedContent, expectedContent)
+    }
+
     func test_accessorContent_accessControlPublic() throws {
         let datasourceUrl = Bundle.module.url(forResource: "TestDatasource", withExtension: "json")!
         let generator = try Generator(datasourceUrl: datasourceUrl)
@@ -80,6 +92,19 @@ final class GeneratorTests: XCTestCase {
         XCTAssertEqual(generatedContent, expectedContent)
     }
     
+    func test_givenAccessControlNil_whenGenerateAccessor_thenAccessControlIsDefault() throws {
+        let datasourceUrl = Bundle.module.url(forResource: "TestDatasource", withExtension: "json")!
+        let generator = try Generator(datasourceUrl: datasourceUrl)
+        let accessorTemplateUrl = Bundle.module.path(forResource: "Accessor", ofType: "stencil")!
+        let generatedContent = try generator.generateAccessor(accessorTemplatePath: accessorTemplateUrl,
+                                                              variablesEnumName: "TestVariables",
+                                                              accessorClassName: "TestToggleAccessor",
+                                                              accessControl: nil)
+        let variablesUrl = Bundle.module.url(forResource: "TestToggleAccessor_nil", withExtension: "txt")!
+        let expectedContent = try String(contentsOf: variablesUrl)
+        XCTAssertEqual(generatedContent, expectedContent)
+    }
+
     func test_accessorDoesNotSupportDatasourceWithDuplicateVariables() throws {
         let datasourceUrl = Bundle.module.url(forResource: "TestDatasourceWithDuplicateVariables", withExtension: "json")!
         XCTAssertThrowsError(try Generator(datasourceUrl: datasourceUrl)) { error in

--- a/ToggleGen/Tests/Resources/Accessor.stencil
+++ b/ToggleGen/Tests/Resources/Accessor.stencil
@@ -5,18 +5,18 @@
 import Foundation
 import Toggles
 
-{{ accessControl }} class {{ className }} {
+{% if accessControl %}{{ accessControl }} {% endif %}class {{ className }} {
     
     private(set) var manager: ToggleManager
     
-    {{ accessControl }} init(manager: ToggleManager) {
+    {% if accessControl %}{{ accessControl }} {% endif %}init(manager: ToggleManager) {
         self.manager = manager
     }
 }
 
 extension {{ className }} {
 {% for accessorInfo in accessorInfos %}
-    {{ accessControl }} var {{ accessorInfo.propertyName }}: {{ accessorInfo.type }} {
+    {% if accessControl %}{{ accessControl }} {% endif %}var {{ accessorInfo.propertyName }}: {{ accessorInfo.type }} {
         get { manager.value(for: {{ enumName }}.{{ accessorInfo.constant.name }}).{{ accessorInfo.toggleType }}Value! }
         set { manager.set(.{{ accessorInfo.toggleType }}(newValue), for: {{ enumName }}.{{ accessorInfo.constant.name }}) }
     }

--- a/ToggleGen/Tests/Resources/TestToggleAccessor_nil.txt
+++ b/ToggleGen/Tests/Resources/TestToggleAccessor_nil.txt
@@ -1,0 +1,66 @@
+//  TestToggleAccessor.swift
+
+// swiftlint:disable file_length
+
+import Foundation
+import Toggles
+
+class TestToggleAccessor {
+    
+    private(set) var manager: ToggleManager
+    
+    init(manager: ToggleManager) {
+        self.manager = manager
+    }
+}
+
+extension TestToggleAccessor {
+
+    var booleanToggle: Bool {
+        get { manager.value(for: TestVariables.booleanToggle).boolValue! }
+        set { manager.set(.bool(newValue), for: TestVariables.booleanToggle) }
+    }
+
+    var integerToggle: Int {
+        get { manager.value(for: TestVariables.integerToggle).intValue! }
+        set { manager.set(.int(newValue), for: TestVariables.integerToggle) }
+    }
+
+    var numericToggle: Double {
+        get { manager.value(for: TestVariables.numericToggle).numberValue! }
+        set { manager.set(.number(newValue), for: TestVariables.numericToggle) }
+    }
+
+    var stringToggle: String {
+        get { manager.value(for: TestVariables.stringToggle).stringValue! }
+        set { manager.set(.string(newValue), for: TestVariables.stringToggle) }
+    }
+
+    var encryptedToggle: String {
+        get { manager.value(for: TestVariables.encryptedToggle).secureValue! }
+        set { manager.set(.secure(newValue), for: TestVariables.encryptedToggle) }
+    }
+
+    var userDefinedBooleanToggle: Bool {
+        get { manager.value(for: TestVariables.booleanToggle2).boolValue! }
+        set { manager.set(.bool(newValue), for: TestVariables.booleanToggle2) }
+    }
+
+    var userDefinedIntegerToggle: Int {
+        get { manager.value(for: TestVariables.integerToggle2).intValue! }
+        set { manager.set(.int(newValue), for: TestVariables.integerToggle2) }
+    }
+
+    var userDefinedNumericToggle: Double {
+        get { manager.value(for: TestVariables.numericToggle2).numberValue! }
+        set { manager.set(.number(newValue), for: TestVariables.numericToggle2) }
+    }
+
+    var userDefinedStringToggle: String {
+        get { manager.value(for: TestVariables.stringToggle2).stringValue! }
+        set { manager.set(.string(newValue), for: TestVariables.stringToggle2) }
+    }
+
+}
+
+// swiftlint:enable file_length

--- a/ToggleGen/Tests/Resources/TestVariables_nil.txt
+++ b/ToggleGen/Tests/Resources/TestVariables_nil.txt
@@ -1,0 +1,29 @@
+//  TestVariables.swift
+
+// swiftlint:disable file_length
+
+import Foundation
+
+enum TestVariables {
+
+    static let booleanToggle = "boolean_toggle"
+
+    static let integerToggle = "integer_toggle"
+
+    static let numericToggle = "numeric_toggle"
+
+    static let stringToggle = "string_toggle"
+
+    static let encryptedToggle = "encrypted_toggle"
+
+    static let booleanToggle2 = "boolean_toggle_2"
+
+    static let integerToggle2 = "integer_toggle_2"
+
+    static let numericToggle2 = "numeric_toggle_2"
+
+    static let stringToggle2 = "string_toggle_2"
+
+}
+
+// swiftlint:enable file_length

--- a/ToggleGen/Tests/Resources/Variables.stencil
+++ b/ToggleGen/Tests/Resources/Variables.stencil
@@ -4,9 +4,9 @@
 
 import Foundation
 
-{{ accessControl }} enum {{ enumName }} {
+{% if accessControl %}{{ accessControl }} {% endif %}enum {{ enumName }} {
 {% for variable in variables %}
-    {{ accessControl }} static let {{ variable.name }} = "{{ variable.value }}"
+    {% if accessControl %}{{ accessControl }} {% endif %}static let {{ variable.name }} = "{{ variable.value }}"
 {% endfor %}
 }
 


### PR DESCRIPTION
Added support for the default ACL. In the current Swift version `internal` is the `default`, so we can avoid adding it. 