### PR TITLE
Replaced `enableExperimentalFeature` to `enableUpcomingFeature`

### DIFF
--- a/JustTweakMigrator/Package.swift
+++ b/JustTweakMigrator/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
             ],
             path: "Sources",
             swiftSettings: [
-                .enableExperimentalFeature("InternalImportsByDefault"),
-                .enableExperimentalFeature("ExistentialAny")
+                .enableUpcomingFeature("InternalImportsByDefault"),
+                .enableUpcomingFeature("ExistentialAny")
             ]
         ),
         .testTarget(
@@ -34,8 +34,8 @@ let package = Package(
                 .process("Resources")
             ],
             swiftSettings: [
-                .enableExperimentalFeature("InternalImportsByDefault"),
-                .enableExperimentalFeature("ExistentialAny")
+                .enableUpcomingFeature("InternalImportsByDefault"),
+                .enableUpcomingFeature("ExistentialAny")
             ]
         )
     ]

--- a/JustTweakMigrator/Sources/Extensions/Toggle+Encodable.swift
+++ b/JustTweakMigrator/Sources/Extensions/Toggle+Encodable.swift
@@ -18,7 +18,7 @@ extension Toggle: Codable {
         case metadata
     }
     
-    init(from decoder: Decoder) throws {
+    init(from decoder: any Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         variable = try values.decode(ToggleVariable.self, forKey: .variable)
         if let boolValue = try? values.decode(Bool.self, forKey: .bool) {
@@ -42,7 +42,7 @@ extension Toggle: Codable {
         metadata = (try? values.decode(ToggleMetadata.self, forKey: .metadata)) ?? ToggleMetadata(description: "", group: "", propertyName: nil)
     }
     
-    func encode(to encoder: Encoder) throws {
+    func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(variable, forKey: .variable)
         

--- a/JustTweakMigrator/Sources/Extensions/Tweak+Decodable.swift
+++ b/JustTweakMigrator/Sources/Extensions/Tweak+Decodable.swift
@@ -16,7 +16,7 @@ extension Tweak: Decodable {
         case generatedPropertyName = "GeneratedPropertyName"
     }
     
-    init(from decoder: Decoder) throws {
+    init(from decoder: any Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         self.title = try values.decode(String.self, forKey: .title)
         self.group = try values.decode(String.self, forKey: .group)

--- a/JustTweakMigrator/Sources/Extensions/TweakDatasource+Decodable.swift
+++ b/JustTweakMigrator/Sources/Extensions/TweakDatasource+Decodable.swift
@@ -8,7 +8,7 @@ extension TweaksDatasource: Decodable {
         case missingValue
     }
     
-    init(from decoder: Decoder) throws {
+    init(from decoder: any Decoder) throws {
         let values = try decoder.singleValueContainer()
         tweaks = try values.decode([TweakFeature: [TweakVariable: Tweak]].self)
     }

--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
             path: "Sources",
             resources: [.process("Resources")],
             swiftSettings: [
-                .enableExperimentalFeature("InternalImportsByDefault"),
-                .enableExperimentalFeature("ExistentialAny")
+                .enableUpcomingFeature("InternalImportsByDefault"),
+                .enableUpcomingFeature("ExistentialAny")
             ]
         ),
         .testTarget(
@@ -36,8 +36,8 @@ let package = Package(
             path: "Tests",
             resources: [.process("Resources")],
             swiftSettings: [
-                .enableExperimentalFeature("InternalImportsByDefault"),
-                .enableExperimentalFeature("ExistentialAny")
+                .enableUpcomingFeature("InternalImportsByDefault"),
+                .enableUpcomingFeature("ExistentialAny")
             ]
         )
     ]

--- a/Sources/Extensions/Object/Object+Codable.swift
+++ b/Sources/Extensions/Object/Object+Codable.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 extension Object: Codable {
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         
         if let dictionary = try? container.decode([Variable: ObjectSupportedType].self) {
@@ -24,7 +24,7 @@ extension Object: Codable {
         }
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         guard !map.isEmpty else {
             throw EncodingError.invalidValue(map, .init(codingPath: [], debugDescription: "Empty object. Can not be encoded."))
         }

--- a/Sources/Extensions/Object/ObjectSupportedType+Codable.swift
+++ b/Sources/Extensions/Object/ObjectSupportedType+Codable.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 extension ObjectSupportedType: Codable {
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if let bool = try? container.decode(Bool.self) {
@@ -19,7 +19,7 @@ extension ObjectSupportedType: Codable {
         }
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         
         switch self {

--- a/Sources/Extensions/Toggle+Codable.swift
+++ b/Sources/Extensions/Toggle+Codable.swift
@@ -19,7 +19,7 @@ extension Toggle: Codable {
         case object
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         variable = try values.decode(Variable.self, forKey: .variable)
         if let boolValue = try? values.decode(Bool.self, forKey: .bool) {
@@ -46,7 +46,7 @@ extension Toggle: Codable {
         metadata = (try? values.decode(Metadata.self, forKey: .metadata)) ?? Metadata(description: "", group: "")
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(variable, forKey: .variable)
         

--- a/Sources/ObservableObjects/ToggleObservable.swift
+++ b/Sources/ObservableObjects/ToggleObservable.swift
@@ -1,6 +1,6 @@
 //  ToggleObservable.swift
 
-import Combine
+public import Combine
 import Foundation
 
 /// `ObservableObject` tied to a toggle that publishes updates whenever its value changes.

--- a/Sources/Protocols/Logger.swift
+++ b/Sources/Protocols/Logger.swift
@@ -7,6 +7,6 @@ public protocol Logger {
 }
 
 public enum ToggleError: Error {
-    case invalidValueType(Variable, Value, ValueProvider)
-    case insecureValue(Variable, ValueProvider)
+    case invalidValueType(Variable, Value, any ValueProvider)
+    case insecureValue(Variable, any ValueProvider)
 }

--- a/Sources/Providers/LocalValueProvider.swift
+++ b/Sources/Providers/LocalValueProvider.swift
@@ -1,6 +1,6 @@
 //  LocalValueProvider.swift
 
-import Foundation
+public import Foundation
 
 /// Value provider with a local datasource.
 final public class LocalValueProvider {

--- a/Sources/Providers/PersistentValueProvider.swift
+++ b/Sources/Providers/PersistentValueProvider.swift
@@ -1,6 +1,6 @@
 //  PersistentValueProvider.swift
 
-import Foundation
+public import Foundation
 
 private let userDefaultsKeyPrefix = "com.toggles"
 

--- a/Sources/ToggleManager/ToggleManager+Ciphering.swift
+++ b/Sources/ToggleManager/ToggleManager+Ciphering.swift
@@ -22,7 +22,7 @@ extension ToggleManager {
         guard let cipherConfiguration = cipherConfiguration else {
             throw FetchError.missingCipherConfiguration
         }
-        let cipher: Ciphering
+        let cipher: any Ciphering
         switch cipherConfiguration.algorithm {
         case Algorithm.chaCha20Poly1305:
             cipher = ChaCha20Poly1305(key: cipherConfiguration.key)
@@ -49,7 +49,7 @@ extension ToggleManager {
             return ""
         }
         
-        let cipher: Ciphering
+        let cipher: any Ciphering
         switch cipherConfiguration.algorithm {
         case Algorithm.chaCha20Poly1305:
             cipher = ChaCha20Poly1305(key: cipherConfiguration.key)

--- a/Sources/ToggleManager/ToggleManager+Publishing.swift
+++ b/Sources/ToggleManager/ToggleManager+Publishing.swift
@@ -1,6 +1,6 @@
 //  ToggleManager+Publishing.swift
 
-import Combine
+public import Combine
 import Foundation
 
 extension ToggleManager: Publishing {

--- a/Sources/ToggleManager/ToggleManager.swift
+++ b/Sources/ToggleManager/ToggleManager.swift
@@ -1,7 +1,7 @@
 //  ToggleManager.swift
 
-import Combine
-import Foundation
+public import Combine
+public import Foundation
 
 /// Thread-safe facade to interface with toggles.
 final public class ToggleManager: ObservableObject, @unchecked Sendable {
@@ -18,8 +18,8 @@ final public class ToggleManager: ObservableObject, @unchecked Sendable {
         public static let noCaching = ToggleManagerOptions(rawValue: 1 << 2)
     }
     
-    var mutableValueProvider: MutableValueProvider?
-    var valueProviders: [ValueProvider]
+    var mutableValueProvider: (any MutableValueProvider)?
+    var valueProviders: [any ValueProvider]
     var defaultValueProvider: DefaultValueProvider
     var cipherConfiguration: CipherConfiguration?
     
@@ -27,7 +27,7 @@ final public class ToggleManager: ObservableObject, @unchecked Sendable {
     let cache = ValueCache<Variable, Value>()
     var subjectsRefs = [Variable: CurrentValueSubject<Value, Never>]()
     let options: [ToggleManagerOptions]
-    var logger: Logger?
+    var logger: (any Logger)?
     
     @Published var hasOverrides: Bool = false
     
@@ -41,11 +41,11 @@ final public class ToggleManager: ObservableObject, @unchecked Sendable {
     ///   - valueProviders: An array or providers that can retrieve toggle values. The providers must be listed in order of priority.
     ///   - datasourceUrl: The url to a file containing the datasource used the base. If no mutableValueProvider and no valueProviders are provided, the manager will always return the values from the datasource.
     ///   - cipherConfiguration: An optional configuration that needs to be provided in the case any toggle is secure (meaning it needs encryption and decryption).
-    public init(mutableValueProvider: MutableValueProvider? = nil,
-                valueProviders: [ValueProvider] = [],
+    public init(mutableValueProvider: (any MutableValueProvider)? = nil,
+                valueProviders: [any ValueProvider] = [],
                 datasourceUrl: URL,
                 cipherConfiguration: CipherConfiguration? = nil,
-                logger: Logger? = nil,
+                logger: (any Logger)? = nil,
                 options: [ToggleManagerOptions] = []) throws {
         self.mutableValueProvider = mutableValueProvider
         self.valueProviders = valueProviders
@@ -108,7 +108,7 @@ extension ToggleManager {
         return !options.contains(.noCaching)
     }
     
-    private func isValueValid(value: Value, defaultValue: Value?, variableName: Variable, provider: ValueProvider) -> Bool {
+    private func isValueValid(value: Value, defaultValue: Value?, variableName: Variable, provider: any ValueProvider) -> Bool {
         if shouldCheckInvalidValueTypes, let defaultValue, !(value ~= defaultValue) {
             logger?.log(ToggleError.invalidValueType(variableName, value, provider))
             return false

--- a/Sources/Views/TogglesView.swift
+++ b/Sources/Views/TogglesView.swift
@@ -1,6 +1,6 @@
 //  TogglesView.swift
 
-import SwiftUI
+public import SwiftUI
 
 /// A view showcasing all toggles from a provided datasource.
 public struct TogglesView: View {

--- a/ToggleCipher/Package.swift
+++ b/ToggleCipher/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
             ],
             path: "Sources",
             swiftSettings: [
-                .enableExperimentalFeature("InternalImportsByDefault"),
-                .enableExperimentalFeature("ExistentialAny")
+                .enableUpcomingFeature("InternalImportsByDefault"),
+                .enableUpcomingFeature("ExistentialAny")
             ]
         ),
         .testTarget(
@@ -31,8 +31,8 @@ let package = Package(
             dependencies: ["ToggleCipher"],
             path: "Tests",
             swiftSettings: [
-                .enableExperimentalFeature("InternalImportsByDefault"),
-                .enableExperimentalFeature("ExistentialAny")
+                .enableUpcomingFeature("InternalImportsByDefault"),
+                .enableUpcomingFeature("ExistentialAny")
             ]
         )
     ]

--- a/ToggleGen/Package.swift
+++ b/ToggleGen/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
             ],
             path: "Sources",
             swiftSettings: [
-                .enableExperimentalFeature("InternalImportsByDefault"),
-                .enableExperimentalFeature("ExistentialAny")
+                .enableUpcomingFeature("InternalImportsByDefault"),
+                .enableUpcomingFeature("ExistentialAny")
             ]
         ),
         .testTarget(
@@ -36,8 +36,8 @@ let package = Package(
             path: "Tests",
             resources: [.process("Resources")],
             swiftSettings: [
-                .enableExperimentalFeature("InternalImportsByDefault"),
-                .enableExperimentalFeature("ExistentialAny")
+                .enableUpcomingFeature("InternalImportsByDefault"),
+                .enableUpcomingFeature("ExistentialAny")
             ]
         )
     ]

--- a/ToggleGen/Sources/Extensions/Models+Decodable.swift
+++ b/ToggleGen/Sources/Extensions/Models+Decodable.swift
@@ -19,7 +19,7 @@ extension Toggle: Decodable {
         case metadata
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         variable = try values.decode(Variable.self, forKey: .variable)
         if let boolValue = try? values.decode(Bool.self, forKey: .bool) {

--- a/ToggleGen/Sources/Models/Object.swift
+++ b/ToggleGen/Sources/Models/Object.swift
@@ -5,7 +5,7 @@ import Foundation
 struct Object: Equatable, Decodable {
     let map: [String: ObjectSupportedType]
     
-    init(from decoder: Decoder) throws {
+    init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         
         if let dictionary = try? container.decode([String: ObjectSupportedType].self) {

--- a/ToggleGen/Sources/Models/ObjectSupportedType.swift
+++ b/ToggleGen/Sources/Models/ObjectSupportedType.swift
@@ -8,7 +8,7 @@ enum ObjectSupportedType: Equatable, Decodable {
     case number(Double)
     case string(String)
     
-    init(from decoder: Decoder) throws {
+    init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         
         if let bool = try? container.decode(Bool.self) {


### PR DESCRIPTION
Because we already migrated Swift 6 from 5 `enableExperimentalFeature` and now `enableUpcomingFeature`, as a result previously it was not working correctly and caused build time issues on integration. 

- Replaced `enableExperimentalFeature` to `enableUpcomingFeature`
- Fixed errors/warnings caused by 👆